### PR TITLE
Fixes to triangular smoothing matrix

### DIFF
--- a/celeri.ipynb
+++ b/celeri.ipynb
@@ -11,19 +11,12 @@
    ],
    "outputs": [],
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-08-22T18:29:50.539195Z",
-     "iopub.status.busy": "2021-08-22T18:29:50.538938Z",
-     "iopub.status.idle": "2021-08-22T18:29:50.550334Z",
-     "shell.execute_reply": "2021-08-22T18:29:50.549700Z",
-     "shell.execute_reply.started": "2021-08-22T18:29:50.539169Z"
-    },
     "tags": []
    }
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "source": [
     "import addict\n",
     "import numpy as np\n",
@@ -40,13 +33,6 @@
    ],
    "outputs": [],
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-08-22T18:29:51.661926Z",
-     "iopub.status.busy": "2021-08-22T18:29:51.661659Z",
-     "iopub.status.idle": "2021-08-22T18:29:51.956035Z",
-     "shell.execute_reply": "2021-08-22T18:29:51.955292Z",
-     "shell.execute_reply.started": "2021-08-22T18:29:51.661900Z"
-    },
     "tags": []
    }
   },
@@ -64,13 +50,6 @@
    ],
    "outputs": [],
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-08-22T18:29:53.570589Z",
-     "iopub.status.busy": "2021-08-22T18:29:53.570331Z",
-     "iopub.status.idle": "2021-08-22T18:30:09.817977Z",
-     "shell.execute_reply": "2021-08-22T18:30:09.817443Z",
-     "shell.execute_reply.started": "2021-08-22T18:29:53.570561Z"
-    },
     "tags": []
    }
   },
@@ -110,22 +89,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "source": [
-    "celeri.get_all_mesh_smoothing_matrices(meshes)  #TODO: I don't think this is right because I only see terms on the main diagonal.\n",
-    "plt.figure()\n",
-    "plt.imshow(meshes[0].smoothing_matrix.toarray()[0:40, 0:40])\n",
-    "plt.colorbar()\n",
-    "plt.show()"
+    "print(meshes[0].tri_shared_sides_distances[0:5])"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "source": [
+    "share = celeri.get_shared_sides(meshes[0].verts)\n",
+    "tri_shared_sides_distances = celeri.get_tri_shared_sides_distances(share, meshes[0].x_centroid, meshes[0].y_centroid, meshes[0].z_centroid)\n"
    ],
    "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[-1.55687510e-08 -1.33330876e-08 -1.30291923e-08 -1.34961655e-08\n",
+      " -1.19136089e-08]\n"
+     ]
+    },
     {
      "output_type": "display_data",
      "data": {
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "05ec22e197bd4b35bdf8ca87a556125a"
+       "model_id": "fe7116472bd64d3aa82bd6bef7399db5"
       },
       "text/plain": [
        "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
@@ -139,18 +132,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "source": [
+    "celeri.get_all_mesh_smoothing_matrices(meshes)  #TODO: I don't think this is right because I only see terms on the main diagonal.\n",
+    "plt.figure()\n",
+    "plt.imshow(meshes[0].smoothing_matrix[0:40, 0:40])\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ],
    "outputs": [],
    "metadata": {}
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "1c99b817e7692020a25f5bce5fd58f988aabefee874a9cd895a1468d49750c9a"
+   "hash": "55cfa0062a586f3023808ef4acd506a0de54388754d290d649a17aafc8191ff0"
   },
   "kernelspec": {
    "name": "python3",
-   "display_name": "Python 3.9.6 64-bit ('celeri': conda)"
+   "display_name": "Python 3.9.7 64-bit ('celeri': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -162,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
This seems to fix the triangular smoothing matrix from #37. The new results, plotted in the notebook, are similar to those from the Matlab equivalent (though smaller in magnitude since distance scaling in celeri uses meters, not km). There were some funny indexing things that stemmed from changing meshes.share within the distance calculation, but I just do the distance calculation differently so that it avoid changing anything about meshes.share. 