### PR TITLE
Triangular slip constraint development

### DIFF
--- a/celeri/__init__.py
+++ b/celeri/__init__.py
@@ -21,6 +21,8 @@ from .celeri import (
     get_strain_rate_centroid_operator,
     get_mogi_operator,
     get_keep_index_12,
+    get_2component_index,
+    get_3component_index,
     interleave2,
     post_process_estimation,
     plot_meshes,

--- a/celeri/celeri.py
+++ b/celeri/celeri.py
@@ -2306,7 +2306,6 @@ def get_2component_index(indices: np.array) -> np.array:
     idx = np.sort(np.append(2 * (indices + 1) - 2, 2 * (indices + 1) - 1))
     return idx
 
-
 def get_3component_index(indices: np.array) -> np.array:
     """Returns indices into 3-component array, where each entry of input array 
     corresponds to three entries in the 3-component array
@@ -2324,7 +2323,6 @@ def get_3component_index(indices: np.array) -> np.array:
     """
     idx = np.sort(np.append(3 * (indices + 1) - 3, (3 * (indices + 1) - 2, 3 * (indices + 1) - 1)))
     return idx
-
 
 def post_process_estimation(
     estimation: Dict, operators: Dict, station: pd.DataFrame, index: Dict

--- a/celeri/celeri.py
+++ b/celeri/celeri.py
@@ -201,7 +201,7 @@ def read_data(command_file_name):
     else:
         sar = pd.read_csv(os.path.join(base_folder, command.sar_file_name))
         sar = sar.loc[:, ~sar.columns.str.match("Unnamed")]
-    return command, segment, block, meshes, station, mogi, sar
+    return command, segment, block, mesh_param, meshes, station, mogi, sar
 
 
 def cart2sph(x, y, z):
@@ -2265,6 +2265,13 @@ def get_keep_index_12(length_of_array: int) -> np.array:
     idx = np.delete(np.arange(0, length_of_array), np.arange(2, length_of_array, 3))
     return idx
 
+def get_2component_index(indices: np.array) -> np.array:
+    idx = np.sort(np.append(2*indices-1, 2*indices))
+    return idx 
+
+def get_3component_index(indices: np.array) -> np.array:
+    idx = np.sort(np.append(3*indices-2, (3*indices-1, 3*indices)))
+    return idx 
 
 def post_process_estimation(
     estimation: Dict, operators: Dict, station: pd.DataFrame, index: Dict

--- a/celeri/celeri.py
+++ b/celeri/celeri.py
@@ -2265,13 +2265,16 @@ def get_keep_index_12(length_of_array: int) -> np.array:
     idx = np.delete(np.arange(0, length_of_array), np.arange(2, length_of_array, 3))
     return idx
 
+
 def get_2component_index(indices: np.array) -> np.array:
-    idx = np.sort(np.append(2*indices-1, 2*indices))
-    return idx 
+    idx = np.sort(np.append(2 * indices - 1, 2 * indices))
+    return idx
+
 
 def get_3component_index(indices: np.array) -> np.array:
-    idx = np.sort(np.append(3*indices-2, (3*indices-1, 3*indices)))
-    return idx 
+    idx = np.sort(np.append(3 * indices - 2, (3 * indices - 1, 3 * indices)))
+    return idx
+
 
 def post_process_estimation(
     estimation: Dict, operators: Dict, station: pd.DataFrame, index: Dict

--- a/celeri/celeri.py
+++ b/celeri/celeri.py
@@ -127,7 +127,9 @@ def read_data(command_file_name):
             meshes[i].dip_flag = meshes[i].dip != 90
             meshes[i].smoothing_weight = mesh_param[i]["smoothing_weight"]
             meshes[i].n_eigenvalues = mesh_param[i]["n_eigenvalues"]
-            meshes[i].edge_constraints = mesh_param[i]["edge_constraints"]
+            meshes[i].top_slip_rate_constraint = mesh_param[i]["top_slip_rate_constraint"]
+            meshes[i].bot_slip_rate_constraint = mesh_param[i]["bot_slip_rate_constraint"]
+            meshes[i].side_slip_rate_constraint = mesh_param[i]["side_slip_rate_constraint"]
             meshes[i].n_tde = meshes[i].lon1.size
             get_mesh_edge_elements(meshes)
 
@@ -201,7 +203,7 @@ def read_data(command_file_name):
     else:
         sar = pd.read_csv(os.path.join(base_folder, command.sar_file_name))
         sar = sar.loc[:, ~sar.columns.str.match("Unnamed")]
-    return command, segment, block, mesh_param, meshes, station, mogi, sar
+    return command, segment, block, meshes, station, mogi, sar
 
 
 def cart2sph(x, y, z):
@@ -1333,24 +1335,6 @@ def get_mogi_operator(mogi, station, command):
             mogi_operator[2::3, i] = u_up
     return mogi_operator
 
-
-def interleave2(array_1, array_2):
-    interleaved_array = np.empty((array_1.size + array_2.size), dtype=array_1.dtype)
-    interleaved_array[0::2] = array_1
-    interleaved_array[1::2] = array_2
-    return interleaved_array
-
-
-def interleave3(array_1, array_2, array_3):
-    interleaved_array = np.empty(
-        (array_1.size + array_2.size + array_3.size), dtype=array_1.dtype
-    )
-    interleaved_array[0::3] = array_1
-    interleaved_array[1::3] = array_2
-    interleaved_array[2::3] = array_3
-    return interleaved_array
-
-
 def latitude_to_colatitude(lat):
     """
     Convert from latitude to colatitude
@@ -2265,14 +2249,80 @@ def get_keep_index_12(length_of_array: int) -> np.array:
     idx = np.delete(np.arange(0, length_of_array), np.arange(2, length_of_array, 3))
     return idx
 
+def interleave2(array_1, array_2):
+    """Interleaves two arrays, with alternating entries. 
+    Given array_1 = [0, 2, 4, 6] and array_2 = [1, 3, 5, 7]
+    returns
+    [0, 1, 2, 3, 4, 5, 6, 7]
+    This is useful for assembling velocity/slip components into a combined array.
+
+    Args:
+        array_1, array_2 (np.array): Arrays to interleave. Should be equal length
+
+    Returns:
+        interleaved_array (np.array): Interleaved array
+    """
+    interleaved_array = np.empty((array_1.size + array_2.size), dtype=array_1.dtype)
+    interleaved_array[0::2] = array_1
+    interleaved_array[1::2] = array_2
+    return interleaved_array
+
+def interleave3(array_1, array_2, array_3):
+    """Interleaves three arrays, with alternating entries. 
+    Given array_1 = [0, 3, 6, 9], array_2 = [1, 4, 7, 10], and array_3 = [2, 5, 8, 11]
+    returns
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    This is useful for assembling velocity/slip components into a combined array.
+
+    Args:
+        array_1, array_2, array_3 (np.array): Arrays to interleave. Should be equal length
+
+    Returns:
+        interleaved_array (np.array): Interleaved array
+    """
+    interleaved_array = np.empty(
+        (array_1.size + array_2.size + array_3.size), dtype=array_1.dtype
+    )
+    interleaved_array[0::3] = array_1
+    interleaved_array[1::3] = array_2
+    interleaved_array[2::3] = array_3
+    return interleaved_array
 
 def get_2component_index(indices: np.array) -> np.array:
-    idx = np.sort(np.append(2 * indices - 1, 2 * indices))
+    """Returns indices into 2-component array, where each entry of input array 
+    corresponds to two entries in the 2-component array
+    Given indices = [0, 2, 10, 6]  
+    returns
+    [0, 1, 4, 5, 20, 21, 12, 13]
+    This is useful for referencing velocity/slip components corresponding to a set 
+    of stations/faults.
+
+    Args:
+        indices (np.array): Element index array
+
+    Returns:
+        idx (np.array): Component index array (2 * length of indices)
+    """
+    idx = np.sort(np.append(2 * (indices + 1) - 2, 2 * (indices + 1) - 1))
     return idx
 
 
 def get_3component_index(indices: np.array) -> np.array:
-    idx = np.sort(np.append(3 * indices - 2, (3 * indices - 1, 3 * indices)))
+    """Returns indices into 3-component array, where each entry of input array 
+    corresponds to three entries in the 3-component array
+    Given indices = [0, 2, 10, 6]  
+    returns
+    [0, 1, 2, 6, 7, 8, 27, 28, 29, 15, 16, 17]
+    This is useful for referencing velocity/slip components corresponding to a set 
+    of stations/faults.
+
+    Args:
+        indices (np.array): Element index array
+
+    Returns:
+        idx (np.array): Component index array (3 * length of indices)
+    """
+    idx = np.sort(np.append(3 * (indices + 1) - 3, (3 * (indices + 1) - 2, 3 * (indices + 1) - 1)))
     return idx
 
 

--- a/data/global/mesh_parameters.json
+++ b/data/global/mesh_parameters.json
@@ -2,11 +2,9 @@
     {
         "mesh_filename": "slab_contours_GCS_WGS84-trench_LL.msh",
         "smoothing_weight": 1e7,
-        "edge_constraints": [
-            0,
-            1,
-            0
-        ],
+        "top_slip_rate_constraint": 1,
+        "bot_slip_rate_constraint": 1,
+        "side_slip_rate_constraint": 1,
         "n_eigenvalues": 20,
         "a_priori_slip_filename": ""
     }

--- a/data/western_north_america/mesh_parameters.json
+++ b/data/western_north_america/mesh_parameters.json
@@ -3,9 +3,9 @@
         "mesh_filename": "slab_contours_GCS_WGS84-trench_LL.msh",
         "smoothing_weight": 1e7,
         "edge_constraints": [
-            0,
             1,
-            0
+            1,
+            1
         ],
         "n_eigenvalues": 20,
         "a_priori_slip_filename": ""

--- a/data/western_north_america/mesh_parameters.json
+++ b/data/western_north_america/mesh_parameters.json
@@ -2,11 +2,9 @@
     {
         "mesh_filename": "slab_contours_GCS_WGS84-trench_LL.msh",
         "smoothing_weight": 1e7,
-        "edge_constraints": [
-            1,
-            1,
-            1
-        ],
+        "top_slip_rate_constraint": 1,
+        "bot_slip_rate_constraint": 1,
+        "side_slip_rate_constraint": 1,
         "n_eigenvalues": 20,
         "a_priori_slip_filename": ""
     }

--- a/notebooks/celeri.ipynb
+++ b/notebooks/celeri.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -12,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-08-22T18:29:51.661926Z",
@@ -52,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-08-22T18:29:53.570589Z",
@@ -63,10 +72,18 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:The file contains tag data that couldn't be processed.\n"
+     ]
+    }
+   ],
    "source": [
     "command_file_name = \"../data/western_north_america/basic_command.json\"\n",
-    "command, segment, block, meshes, station, mogi, sar = celeri.read_data(command_file_name)\n",
+    "command, segment, block, mesh_param, meshes, station, mogi, sar = celeri.read_data(command_file_name)\n",
     "station = celeri.process_station(station, command)\n",
     "segment = celeri.process_segment(segment, command, meshes)\n",
     "sar = celeri.process_sar(sar, command)\n",
@@ -86,9 +103,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] Unable to open file (unable to open file: name = './celeri_elastic_operators.hdf5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/fg/yxk4m2b97gd8fx9whgk386y5szvp8k/T/ipykernel_91388/3097881001.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Get all elastic operators for segments and TDEs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mceleri\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_elastic_operators\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moperators\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmeshes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msegment\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcommand\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# Get TDE smoothing operators\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mceleri\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_all_mesh_smoothing_matrices\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmeshes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moperators\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/python/celeri/celeri/celeri.py\u001b[0m in \u001b[0;36mget_elastic_operators\u001b[0;34m(operators, meshes, segment, station, command)\u001b[0m\n\u001b[1;32m   1217\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1218\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mcommand\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreuse_elastic\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"yes\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1219\u001b[0;31m         \u001b[0mhdf5_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5py\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcommand\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreuse_elastic_file\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"r\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1220\u001b[0m         operators.slip_rate_to_okada_to_velocities = np.array(\n\u001b[1;32m   1221\u001b[0m             \u001b[0mhdf5_file\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"slip_rate_to_okada_to_velocities\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/celeri/lib/python3.10/site-packages/h5py/_hl/files.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name, mode, driver, libver, userblock_size, swmr, rdcc_nslots, rdcc_nbytes, rdcc_w0, track_order, fs_strategy, fs_persist, fs_threshold, fs_page_size, page_buf_size, min_meta_keep, min_raw_keep, locking, **kwds)\u001b[0m\n\u001b[1;32m    505\u001b[0m                                  \u001b[0mfs_persist\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfs_persist\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfs_threshold\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfs_threshold\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    506\u001b[0m                                  fs_page_size=fs_page_size)\n\u001b[0;32m--> 507\u001b[0;31m                 \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmake_fid\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muserblock_size\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfcpl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mswmr\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mswmr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    508\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    509\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlibver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtuple\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/celeri/lib/python3.10/site-packages/h5py/_hl/files.py\u001b[0m in \u001b[0;36mmake_fid\u001b[0;34m(name, mode, userblock_size, fapl, fcpl, swmr)\u001b[0m\n\u001b[1;32m    218\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mswmr\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mswmr_support\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m             \u001b[0mflags\u001b[0m \u001b[0;34m|=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mACC_SWMR_READ\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfapl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'r+'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0mfid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mh5f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mACC_RDWR\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfapl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfapl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mh5py/_objects.pyx\u001b[0m in \u001b[0;36mh5py._objects.with_phil.wrapper\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mh5py/_objects.pyx\u001b[0m in \u001b[0;36mh5py._objects.with_phil.wrapper\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mh5py/h5f.pyx\u001b[0m in \u001b[0;36mh5py.h5f.open\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] Unable to open file (unable to open file: name = './celeri_elastic_operators.hdf5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)"
+     ]
+    }
+   ],
    "source": [
     "# Get all elastic operators for segments and TDEs\n",
     "celeri.get_elastic_operators(operators, meshes, segment, station, command)\n",
@@ -96,6 +131,56 @@
     "# Get TDE smoothing operators\n",
     "celeri.get_all_mesh_smoothing_matrices(meshes, operators)\n",
     "celeri.get_all_mesh_smoothing_matrices_simple(meshes, operators)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "142\n"
+     ]
+    }
+   ],
+   "source": [
+    "import scipy\n",
+    "\n",
+    "for i in range(len(meshes)):\n",
+    "    # Empty constraint matrix\n",
+    "    tri_slip_rate_constraints = np.zeros(\n",
+    "        (2 * meshes[i].n_tde, 2 * meshes[i].n_tde)\n",
+    "    )\n",
+    "    # Top constraints\n",
+    "    if meshes[i].edge_constraints[0] > 0:\n",
+    "        # Indices of top elements\n",
+    "        top_indices = np.asarray(np.where(meshes[i].top_elements))\n",
+    "        # Indices of top elements' 2 slip components\n",
+    "        top_idx = celeri.get_2component_index(top_indices)\n",
+    "        tri_slip_rate_constraints[top_idx, top_idx] = 1\n",
+    "    # Bottom constraints\n",
+    "    if meshes[i].edge_constraints[1] > 0:\n",
+    "        # Indices of bottom elements\n",
+    "        bot_indices = np.asarray(np.where(meshes[i].bot_elements))\n",
+    "        # Indices of bottom elements' 2 slip components\n",
+    "        bot_idx = celeri.get_2component_index(bot_indices)\n",
+    "        tri_slip_rate_constraints[bot_idx, bot_idx] = 1\n",
+    "    # Side constraints\n",
+    "    if meshes[i].edge_constraints[2] > 0:\n",
+    "        # Indices of side elements\n",
+    "        side_indices = np.asarray(np.where(meshes[i].side_elements))\n",
+    "        # Indices of side elements' 2 slip components\n",
+    "        side_idx = celeri.get_2component_index(side_indices)\n",
+    "        tri_slip_rate_constraints[side_idx, side_idx] = 1\n",
+    "    # Eliminate blank rows\n",
+    "    sum_constraint_columns = np.sum(tri_slip_rate_constraints, 1)\n",
+    "    tri_slip_rate_constraints = tri_slip_rate_constraints[sum_constraint_columns > 0, :]\n",
+    "    operators.meshes[i].tri_slip_rate_constraints = tri_slip_rate_constraints\n",
+    "    meshes[i].n_tde_constraints = np.sum(sum_constraint_columns > 0)\n",
+    "    \n"
    ]
   },
   {
@@ -180,9 +265,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "unsupported operand type(s) for *: 'int' and 'Dict'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/fg/yxk4m2b97gd8fx9whgk386y5szvp8k/T/ipykernel_91388/882439917.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend_block_col\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m3\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mblock\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstart_block_constraints_row\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend_station_row\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend_block_constraints_row\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstart_block_constraints_row\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m3\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mn_block_constraints\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     18\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mn_slip_rate_constraints\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0massembly\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mslip_rate_constraints\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msize\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstart_slip_rate_constraints_row\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mindex\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mend_block_constraints_row\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: unsupported operand type(s) for *: 'int' and 'Dict'"
+     ]
+    }
+   ],
    "source": [
     "# TODO: What should this conversion be?\n",
     "DEG_PER_MYR_TO_RAD_PER_YR = np.deg2rad(1) / 1e6\n",
@@ -210,16 +307,21 @@
     "for i in range(len(meshes)):\n",
     "    index.meshes[i].n_tde = meshes[i].n_tde\n",
     "    index.n_tde_total += index.meshes[i].n_tde\n",
+    "    index.meshes[i].n_tde_constraints = meshes[i].n_tde_constraints\n",
     "    if i == 0:\n",
     "        index.meshes[i].start_tde_col = index.end_block_col\n",
     "        index.meshes[i].end_tde_col = index.meshes[i].start_tde_col + 2 * index.meshes[i].n_tde\n",
     "        index.meshes[i].start_tde_smoothing_row = index.end_slip_rate_constraints_row\n",
     "        index.meshes[i].end_tde_smoothing_row = index.meshes[i].start_tde_smoothing_row + 2 * index.meshes[i].n_tde\n",
+    "        index.meshes[i].start_tde_constraint_row = index.meshes[i].end_tde_smoothing_row\n",
+    "        index.meshes[i].end_tde_constraint_row = index.meshes[i].start_tde_constraint_row + 2 * index.meshes[i].n_tde_constraints\n",
     "    else:\n",
     "        index.meshes[i].start_tde_col = index.meshes[i - 1].end_tde_col\n",
     "        index.meshes[i].end_tde_col = index.meshes[i].start_tde_col + 2 * index.meshes[i].n_tde\n",
     "        index.meshes[i].start_tde_smoothing_row = index.meshes[i - 1].end_tde_smoothing_row\n",
     "        index.meshes[i].end_tde_smoothing_row = index.meshes[i].start_tde_smoothing_row + 2 * index.meshes[i].n_tde\n",
+    "        index.meshes[i].start_tde_constraint_row = index.meshes[i - 1].end_tde_smoothing_row\n",
+    "        index.meshes[i].end_tde_constraint_row = index.meshes[i].start_tde_constraint_row + 2 * index.meshes[i].n_tde_constraints\n",
     "\n",
     "index.start_tde_col = index.end_block_col\n",
     "index.end_tde_col = index.start_tde_col + 2 * index.meshes[0].n_tde\n",


### PR DESCRIPTION
Currently implemented in a code block in `celeri.ipynb`. Need to move to a function within `celeri.py`. Currently only works for setting any edge combination to creeping. 

- Modified `mesh_parameters.json` to force creep on top, bottom, and sides, just to test method. Tested with [0, 1, 0], [1, 1, 0], and [1, 1, 1] and all work
- Modified general smoothing solution. Previously, smoothing matrix was multiplied by smoothing weight in the operator construction, but smoothing weight should instead go into the weighting vector. I'm curious about weighting vector construction (raw data uncertainties used, rather than reciprocal of their squares), and clearly this implementation of smoothing yields wacky TDE slip rate values 
- Added two new utility functions to `celeri.py`: `get_2component_index` and `get_3component_index`. These general index arrays multiple components given indices of an object. For example, if we want to find the index into a slip component matrix for elements [2, 7, 10], `get_2component_index` will return [3, 4, 13, 14, 19, 20]. 