### PR TITLE
Explicitly check if lockfile needs to be updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         os: ["ubuntu-latest"]
         pixi-environment: ["py39", "default"]
         tests-to-run: ["japan", "other"]
-    name: Test (${{ matrix.pixi-environment }}, ${{ matrix.os }})
+    name: Test (${{ matrix.pixi-environment }}, ${{ matrix.tests-to-run }})
     runs-on:  ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,21 @@ name: Test
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
 
 jobs:
+  check-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: prefix-dev/setup-pixi@v0.8.5
+      with:
+        run-install: false
+    - name: Check if pixi lockfile is up-to-date
+      run: pixi list --locked
   test:
     strategy:
       fail-fast: false
@@ -21,7 +32,9 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
-    - uses: prefix-dev/setup-pixi@v0.8.3
+      with:
+        fetch-depth: 0
+    - uses: prefix-dev/setup-pixi@v0.8.5
       with:
         cache: true
         environments: ${{ matrix.pixi-environment }}


### PR DESCRIPTION
Before, if the lockfile wasn't up-to-date, the error message was somewhat vague.

This just adds a separate step where we check the pixi lockfile, so if the lockfile isn't up-to-date, then the explicit `Check if pixi lockfile is up-to-date` step will fail, hopefully making it easier to understand what's wrong.