### PR TITLE
Add support for annealing

### DIFF
--- a/celeri/optimize.py
+++ b/celeri/optimize.py
@@ -1049,7 +1049,7 @@ class MinimizerTrace:
         print(f"Iteration: {iter_num}")
         print(f"{oob} of {total} velocities are out-of-bounds")
         print(f"Non-convex constraint loss: {nonconvex_loss:.2e}")
-        print(f"residual 2-norm: {objective:.5e}")
+        print(f"residual 2-norm: {objective}")
         print(f"Iteration took {iter_time:.2f}s")
         print()
 

--- a/celeri/optimize.py
+++ b/celeri/optimize.py
@@ -1198,9 +1198,7 @@ def minimize(
     verbose: bool = False,
     rescale_parameters: bool = True,
     rescale_constraints: bool = True,
-    objective: Literal[
-        "expanded_norm2", "sum_of_squares", "norm1", "norm2"
-    ] = "expanded_norm2",
+    objective: Objective = "expanded_norm2",
     annealing_schedule: list[float] | None = None,
 ) -> MinimizerTrace:
     """Iteratively solve a constrained optimization problem for fault slip rates.

--- a/celeri/optimize.py
+++ b/celeri/optimize.py
@@ -938,6 +938,8 @@ def _tighten_kinematic_bounds(
     velocity_lower: float,
     tighten_all: bool = True,
     factor: float = 0.5,
+    iteration_number: int,
+    num_oob: int,
 ):
     assert factor > 0 and factor < 1
 
@@ -1229,7 +1231,7 @@ def minimize(
 
     solver = default_solve_kwargs.pop("solver")
 
-    for _num_iter in range(max_iter):
+    for iteration_number in range(max_iter):
         _custom_solve(
             minimizer.cp_problem,
             solver=solver,
@@ -1250,6 +1252,8 @@ def minimize(
             velocity_lower=velocity_lower,
             factor=reduction_factor,
             tighten_all=True,
+            iteration_number=iteration_number,
+            num_oob=num_oob,
         )
 
     return trace


### PR DESCRIPTION
Adds an `annealing_schedule` argument to `celeri.optimize.minimize()`.

Specify a list of looseness values (mm/yr) for relaxing the constraints after the out-of-bounds values have all been fixed. Example, `annealing_schedule=[0.125, 0.125, 0.125]` will result in the following `qr_sum_of_squares` losses, filtered to show only those iterations that have settled to no out-of-bounds:

(0-indexed iteration number, residual 2-norm):
```python
[(12, np.float64(42.74860926501867)),
 (21, np.float64(42.73955301805384)),
 (31, np.float64(42.73733186733481)),
 (36, np.float64(42.737317450844806))]
```

For more details and visualizations, see #154.