### PR TITLE
Define scripts as entry points in pyproject.toml

### DIFF
--- a/celeri/scripts/celeri_report.py
+++ b/celeri/scripts/celeri_report.py
@@ -416,7 +416,38 @@ def read_process_run_folder(folder_name: str):
     return run
 
 
-def main(args: Dict):
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--folder_name_1",
+        type=str,
+        default=None,
+        required=False,
+        help="Name of of folder 1.  If omited it will assome the most recent model run folder.",
+    )
+    parser.add_argument(
+        "--folder_name_2",
+        type=str,
+        default=None,
+        required=False,
+        help="Name of of folder 2.",
+    )
+    parser.add_argument(
+        "--diff_back",
+        type=int,
+        default=None,
+        required=False,
+        help="Name of of folder 2.",
+    )
+    parser.add_argument(
+        "--repl",
+        type=int,
+        default=0,
+        required=False,
+        help="Start ipython REPL.",
+    )
+    args = addict.Dict(vars(parser.parse_args()))
+
     # Case 1: No arguments passed.  Report on diff between two most recent folders
     if args.folder_name_1 == None:
         list_of_folders = filter(os.path.isdir, glob.glob("./../runs/*"))
@@ -466,34 +497,4 @@ def main(args: Dict):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--folder_name_1",
-        type=str,
-        default=None,
-        required=False,
-        help="Name of of folder 1.  If omited it will assome the most recent model run folder.",
-    )
-    parser.add_argument(
-        "--folder_name_2",
-        type=str,
-        default=None,
-        required=False,
-        help="Name of of folder 2.",
-    )
-    parser.add_argument(
-        "--diff_back",
-        type=int,
-        default=None,
-        required=False,
-        help="Name of of folder 2.",
-    )
-    parser.add_argument(
-        "--repl",
-        type=int,
-        default=0,
-        required=False,
-        help="Start ipython REPL.",
-    )
-    args = addict.Dict(vars(parser.parse_args()))
-    main(args)
+    main()

--- a/celeri/scripts/celeri_solve.py
+++ b/celeri/scripts/celeri_solve.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 from loguru import logger
-from typing import Dict
 import IPython
 import celeri
 
 
 @logger.catch
-def main(args: Dict):
+def main():
+    args = celeri.parse_args()
     # Read in command file and start logging
     command = celeri.get_command(args.command_file_name)
     celeri.create_output_folder(command)
@@ -50,5 +50,4 @@ def main(args: Dict):
 
 
 if __name__ == "__main__":
-    args = celeri.parse_args()
-    main(args)
+    main()

--- a/celeri/scripts/segment_meshing_function.py
+++ b/celeri/scripts/segment_meshing_function.py
@@ -22,7 +22,15 @@ M2MM = 1.0e3
 RADIUS_EARTH = np.float64((GEOID.a + GEOID.b) / 2)
 
 
-def main(args):
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command_file_name",
+        type=str,
+        help="Name of command file.",
+    )
+    args = dict(vars(parser.parse_args()))
+
     command = celeri.get_command(args["command_file_name"])
     logger = celeri.get_logger(command)
     segment, block, meshes, station, mogi, sar = celeri.read_data(command)
@@ -286,11 +294,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "command_file_name",
-        type=str,
-        help="Name of command file.",
-    )
-    args = dict(vars(parser.parse_args()))
-    main(args)
+    main()

--- a/celeri/scripts/snap_segments.py
+++ b/celeri/scripts/snap_segments.py
@@ -189,7 +189,20 @@ def make_default_segment(length):
 
 
 @logger.catch
-def main(args: Dict):
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "segment_file_name",
+        type=str,
+        help="Name of segment file.",
+    )
+    parser.add_argument(
+        "mesh_parameters_file_name",
+        type=str,
+        help="Name of mesh parameter file.",
+    )
+    args = addict.Dict(vars(parser.parse_args()))
+
     # Read segment data
     segment = pd.read_csv(args.segment_file_name)
     segment = segment.loc[:, ~segment.columns.str.match("Unnamed")]
@@ -292,16 +305,4 @@ def main(args: Dict):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "segment_file_name",
-        type=str,
-        help="Name of segment file.",
-    )
-    parser.add_argument(
-        "mesh_parameters_file_name",
-        type=str,
-        help="Name of mesh parameter file.",
-    )
-    args = addict.Dict(vars(parser.parse_args()))
-    main(args)
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.scripts]
+celeri-gmt = "celeri.scripts.celeri_gmt:main"
+celeri-report = "celeri.scripts.celeri_report:main"
+celeri-solve = "celeri.scripts.celeri_solve:main"
+celeri-snap-segments = "celeri.scripts.snap_segments:main"
+celeri-segment-meshing-function = "celeri.scripts.segment_meshing_function:main"
+
 [project.urls]
 Homepage = "https://github.com/brendanjmeade/celeri"
 


### PR DESCRIPTION
Closes #159 

With this change, after reinstalling the `celeri package` (e.g. by `pixi install` or `pip install -e .`), the scripts will be "globally" accessible as long as an environment has been activated in which `celeri` is installed.

You may want to tweak the names of the scripts, e.g. you could change `celeri-segment-meshing-function` to `segment_meshing_function` if you want.