### PR TITLE
fix: don't double constraints in optimizer

### DIFF
--- a/notebooks/compare_optimizers.ipynb
+++ b/notebooks/compare_optimizers.ipynb
@@ -626,7 +626,7 @@
     "    solver=\"CLARABEL\",\n",
     "    equilibrate_enable=False,\n",
     "    direct_solve_method=\"faer\",\n",
-    "    ignore_dpp=False,\n",
+    "    ignore_dpp=True,\n",
     "    verbose=False,\n",
     ")\n",
     "\n",
@@ -636,7 +636,6 @@
     "    velocity_upper=110.0,\n",
     "    velocity_lower=-110.0,\n",
     "    solve_kwargs=solve_kwargs,\n",
-    "    default_constraints=True,\n",
     "    objective=\"qr_sum_of_squares\",\n",
     "    operators=operators,\n",
     ")"
@@ -705,7 +704,7 @@
     "    solver=\"CLARABEL\",\n",
     "    equilibrate_enable=False,\n",
     "    direct_solve_method=\"faer\",\n",
-    "    ignore_dpp=False,\n",
+    "    ignore_dpp=True,\n",
     "    verbose=False,\n",
     ")\n",
     "\n",
@@ -715,7 +714,6 @@
     "    velocity_upper=110.0,\n",
     "    velocity_lower=-110.0,\n",
     "    solve_kwargs=solve_kwargs,\n",
-    "    default_constraints=True,\n",
     "    objective=\"qr_sum_of_squares\",\n",
     "    operators=operators,\n",
     ")"


### PR DESCRIPTION
This removes the duplicate constraints in the new optimizer. On my (slow) machine, the japan example now runs in 1min instead of 3min.