### PR TITLE
Add mesh_idx to model_meshes.csv

### DIFF
--- a/celeri/output.py
+++ b/celeri/output.py
@@ -104,6 +104,7 @@ def write_output(
                 "lon3": meshes[i].lon3,
                 "lat3": meshes[i].lat3,
                 "dep3": meshes[i].dep3,
+                "mesh_idx": i * np.ones_like(meshes[i].lon1).astype(int),
             }
             this_mesh_output = pd.DataFrame(this_mesh_output)
             # mesh_outputs = mesh_outputs.append(this_mesh_output)


### PR DESCRIPTION
A tiny change: I'd like to [write an integer `mesh_idx` column](https://github.com/brendanjmeade/celeri/blob/fda075ff6b033f2e1c3eb22bb2b67c4731dc85d6/celeri/output.py#L107) to the `model_meshes.csv` that is written by `output.py`. This will be helpful for subsequent visualization in `result_manager`. 