### PR TITLE
Make update-pixi-lockfile run in the create-pr GH environment

### DIFF
--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   pixi-update:
     runs-on: ubuntu-latest
+    environment: create-pr
     steps:
     - uses: actions/checkout@v4
     - name: Set up pixi


### PR DESCRIPTION
@brendanjmeade, after following the instructions sent via DM on how to create the personal access token, this commit should resolve the failure observed in https://github.com/brendanjmeade/celeri/actions/runs/16437315865.