### PR TITLE
feat: add missing accessors Estimation.tde_*_rate

### DIFF
--- a/celeri/plot.py
+++ b/celeri/plot.py
@@ -579,11 +579,18 @@ def plot_estimation_summary(
             plt.title("TDE slip (strike-slip)")
             common_plot_elements(segment, lon_range, lat_range)
             # plot_meshes(meshes, estimation.tde_strike_slip_rates, plt.gca())
-            fill_value = estimation.tde_strike_slip_rates
-            assert fill_value is not None
-            fill_value_range = (float(np.min(fill_value)), float(np.max(fill_value)))
+            fill_value_dict = estimation.tde_strike_slip_rates
+            assert fill_value_dict is not None
+            fill_value_range = (0, 0)
+            for mesh_idx in fill_value_dict:
+                fill_value_range = (
+                    min(fill_value_range[0], float(np.min(fill_value_dict[mesh_idx]))),
+                    max(fill_value_range[1], float(np.max(fill_value_dict[mesh_idx]))),
+                )
+
             ax = plt.gca()
             for i in range(len(meshes)):
+                fill_value = fill_value_dict[i]
                 x_coords = meshes[i].points[:, 0]
                 y_coords = meshes[i].points[:, 1]
                 vertex_array = np.asarray(meshes[i].verts)
@@ -593,15 +600,7 @@ def plot_estimation_summary(
                 pc = matplotlib.collections.PolyCollection(
                     verts, edgecolor="none", cmap="rainbow"
                 )
-                if i == 0:
-                    tde_slip_component_start = 0
-                    tde_slip_component_end = meshes[i].n_tde
-                else:
-                    tde_slip_component_start = tde_slip_component_end
-                    tde_slip_component_end = tde_slip_component_start + meshes[i].n_tde
-                pc.set_array(
-                    fill_value[tde_slip_component_start:tde_slip_component_end]
-                )
+                pc.set_array(fill_value)
                 pc.set_clim(fill_value_range)
                 ax.add_collection(pc)
                 # ax.autoscale()
@@ -622,11 +621,17 @@ def plot_estimation_summary(
             plt.title("TDE slip (dip-slip)")
             common_plot_elements(segment, lon_range, lat_range)
             # plot_meshes(meshes, estimation.tde_dip_slip_rates, plt.gca())
-            fill_value = estimation.tde_dip_slip_rates
-            assert fill_value is not None
-            fill_value_range = (float(np.min(fill_value)), float(np.max(fill_value)))
+            fill_value_dict = estimation.tde_dip_slip_rates
+            assert fill_value_dict is not None
+            fill_value_range = (0, 0)
+            for mesh_idx in fill_value_dict:
+                fill_value_range = (
+                    min(fill_value_range[0], float(np.min(fill_value_dict[mesh_idx]))),
+                    max(fill_value_range[1], float(np.max(fill_value_dict[mesh_idx]))),
+                )
             ax = plt.gca()
             for i in range(len(meshes)):
+                fill_value = fill_value_dict[i]
                 x_coords = meshes[i].points[:, 0]
                 y_coords = meshes[i].points[:, 1]
                 vertex_array = np.asarray(meshes[i].verts)
@@ -636,15 +641,7 @@ def plot_estimation_summary(
                 pc = matplotlib.collections.PolyCollection(
                     verts, edgecolor="none", cmap="rainbow"
                 )
-                if i == 0:
-                    tde_slip_component_start = 0
-                    tde_slip_component_end = meshes[i].n_tde
-                else:
-                    tde_slip_component_start = tde_slip_component_end
-                    tde_slip_component_end = tde_slip_component_start + meshes[i].n_tde
-                pc.set_array(
-                    fill_value[tde_slip_component_start:tde_slip_component_end]
-                )
+                pc.set_array(fill_value)
                 pc.set_clim(fill_value_range)
                 ax.add_collection(pc)
                 # ax.autoscale()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -268,7 +268,8 @@ def test_estimation_serialization(config_file, temp_dir):
 
     if original_estimation.tde_rates is not None:
         assert deserialized_estimation.tde_rates is not None
-        np.testing.assert_allclose(
-            original_estimation.tde_rates,
-            deserialized_estimation.tde_rates,
-        )
+        for mesh_idx in original_estimation.tde_rates:
+            np.testing.assert_allclose(
+                original_estimation.tde_rates[mesh_idx],
+                deserialized_estimation.tde_rates[mesh_idx],
+            )


### PR DESCRIPTION
Properties like `Estimation.tde_strike_slip_rates_kinematic` were only TODO stubs even before the refactor, and still only returned zeros.
I replaced them with actual implementations, and added separate ones for the smoothed kinematic rates. The properties also return dict with mesh indices as keys now, instead of the concatenated values, because I think we only ever want to use values that are specific to a particular mesh. That avoids having to first concatenate and then split them again (and possibly introducing errors along the way).

@brendanjmeade I think this unblocks and fixes #218, but let me know if there are further issues with it.