### PR TITLE
Add individual mesh slip rates to output dataframe in solve.py

### DIFF
--- a/celeri/solve.py
+++ b/celeri/solve.py
@@ -133,14 +133,20 @@ class Estimation:
                 "lat3": meshes[i].lat3,
                 "dep3": meshes[i].dep3,
                 "mesh_idx": i * np.ones_like(meshes[i].lon1).astype(int),
+                "strike_slip_rate": self.tde_strike_slip_rates[i],
+                "dip_slip_rate": self.tde_dip_slip_rates[i],
+                "strike_slip_rate_kinematic": self.tde_strike_slip_rates_kinematic_smooth[
+                    i
+                ],
+                "dip_slip_rate_kinematic": self.tde_dip_slip_rates_kinematic_smooth[i],
             }
             this_mesh_output = pd.DataFrame(this_mesh_output)
             # mesh_outputs = mesh_outputs.append(this_mesh_output)
             mesh_outputs = pd.concat([mesh_outputs, this_mesh_output])
 
         # Append slip rates
-        mesh_outputs["strike_slip_rate"] = self.tde_strike_slip_rates
-        mesh_outputs["dip_slip_rate"] = self.tde_dip_slip_rates
+        # mesh_outputs["strike_slip_rate"] = self.tde_strike_slip_rates
+        # mesh_outputs["dip_slip_rate"] = self.tde_dip_slip_rates
         return mesh_outputs
 
     @cached_property


### PR DESCRIPTION
Adding `"strike_slip_rate": self.tde_strike_slip_rates[i]` and similar within the [`mesh_estimate` loop of `solve.py`](https://github.com/brendanjmeade/celeri/blob/2f1c7342234313a720c4be54290e7d96a19133d6/celeri/solve.py#L136) so that slip rates can be written to `model_meshes.csv`. 

I'm getting the Pylance error `Object of type "None" is not subscriptable` for the coupling values, but they seem to be written correctly to `model_meshes.csv`. 