### PR TITLE
Treat pixi.lock as binary to prevent 3-way merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# SCM syntax highlighting
-pixi.lock linguist-language=YAML linguist-generated=true
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true


### PR DESCRIPTION
Rebasing in https://github.com/brendanjmeade/celeri/pull/233 should have failed, but it succeeded because Git is treating the lockfile as mergeable text. This is slightly dangerous to consistency of the lockfile.

Newer versions of pixi generate a `.gitattributes` file to treat the lockfile correctly, but we generated this file with an older version. This PR updates the `.gitattributes` to the newer style.