### PR TITLE
First draft of script to create BEL meshes based on an existing mesh

### DIFF
--- a/celeri/scripts/create_bel_mesh.py
+++ b/celeri/scripts/create_bel_mesh.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+import gmsh
+import meshio
+import numpy as np
+from scipy.spatial import ConvexHull
+from shapely.geometry import Polygon
+from shapely.ops import transform
+import pyproj
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a horizontal mesh from an existing .msh file with buffered convex hull"
+    )
+    parser.add_argument("msh_file", help="Input MSH file path", type=Path)
+    parser.add_argument(
+        "msh_buffer_length_scale",
+        type=float,
+        help="Buffer length scale in kilometers",
+    )
+    parser.add_argument(
+        "msh_depth",
+        type=float,
+        help="Depth in kilometers (will be made negative)",
+    )
+    parser.add_argument(
+        "msh_element_length_scale",
+        type=float,
+        help="Target mesh element length scale in kilometers",
+    )
+    args = parser.parse_args()
+
+    # Ensure depth is negative
+    depth = -abs(args.msh_depth)
+    
+    # Read the input mesh file
+    print(f"Reading mesh file: {args.msh_file}")
+    mesh = meshio.read(args.msh_file)
+    
+    # Extract lon/lat coordinates from mesh points
+    points = mesh.points
+    lons = points[:, 0]
+    lats = points[:, 1]
+    
+    # Create convex hull around the lon/lat points
+    print("Computing convex hull...")
+    coords = np.column_stack((lons, lats))
+    hull = ConvexHull(coords)
+    hull_points = coords[hull.vertices]
+    
+    # Create a Shapely polygon from the convex hull
+    polygon = Polygon(hull_points)
+    
+    # Buffer the polygon by the specified distance in kilometers
+    print(f"Buffering convex hull by {args.msh_buffer_length_scale} km...")
+    
+    # Calculate the center of the polygon for projection
+    center_lon = polygon.centroid.x
+    center_lat = polygon.centroid.y
+    
+    # Create a local projection centered on the mesh
+    proj_string = f"+proj=aeqd +lat_0={center_lat} +lon_0={center_lon} +datum=WGS84 +units=m"
+    transformer_to_local = pyproj.Transformer.from_crs("EPSG:4326", proj_string, always_xy=True)
+    transformer_to_lonlat = pyproj.Transformer.from_crs(proj_string, "EPSG:4326", always_xy=True)
+    
+    # Transform to local coordinates, buffer, then transform back
+    polygon_local = transform(transformer_to_local.transform, polygon)
+    buffer_distance_m = args.msh_buffer_length_scale * 1000  # Convert km to m
+    buffered_polygon_local = polygon_local.buffer(buffer_distance_m)
+    buffered_polygon = transform(transformer_to_lonlat.transform, buffered_polygon_local)
+    
+    # Extract the boundary coordinates and resample uniformly
+    boundary = buffered_polygon.exterior
+    
+    # Calculate the perimeter in the local coordinate system for accurate distance
+    boundary_local = transform(transformer_to_local.transform, boundary)
+    perimeter_length = boundary_local.length
+    
+    # Calculate number of points based on desired element size
+    # Use smaller spacing on boundary to ensure good mesh quality
+    boundary_spacing = args.msh_element_length_scale * 1000 * 0.5  # Half the element size in meters
+    num_points = max(int(perimeter_length / boundary_spacing), 20)  # At least 20 points
+    
+    print(f"Resampling boundary with {num_points} uniformly spaced points...")
+    
+    # Resample the boundary with uniform spacing
+    resampled_points = []
+    for i in range(num_points):
+        # Get point at uniform distance along the boundary
+        point = boundary_local.interpolate(i * perimeter_length / num_points)
+        # Transform back to lon/lat
+        lon, lat = transformer_to_lonlat.transform(point.x, point.y)
+        resampled_points.append((lon, lat))
+    
+    # Create a new mesh using gmsh
+    print(f"Creating new mesh with element size {args.msh_element_length_scale} km...")
+    gmsh.initialize()
+    gmsh.model.add("horizontal_mesh")
+    
+    # Add points to gmsh
+    point_tags = []
+    for lon, lat in resampled_points:
+        tag = gmsh.model.geo.addPoint(lon, lat, depth, args.msh_element_length_scale)
+        point_tags.append(tag)
+    
+    # Create lines connecting the points
+    line_tags = []
+    for i in range(len(point_tags)):
+        j = (i + 1) % len(point_tags)
+        tag = gmsh.model.geo.addLine(point_tags[i], point_tags[j])
+        line_tags.append(tag)
+    
+    # Create a curve loop and surface
+    curve_loop = gmsh.model.geo.addCurveLoop(line_tags)
+    surface = gmsh.model.geo.addPlaneSurface([curve_loop])
+    
+    # Synchronize and generate the mesh
+    gmsh.model.geo.synchronize()
+    gmsh.model.mesh.generate(2)  # 2D mesh
+    
+    # Set all node depths to the specified value
+    print(f"Setting all node depths to {depth} km...")
+    node_tags, node_coords, _ = gmsh.model.mesh.getNodes()
+    coords = np.array(node_coords).reshape(-1, 3)
+    coords[:, 2] = depth  # Set all z-values to the specified depth
+    
+    for i, tag in enumerate(node_tags):
+        x, y, z = coords[i]
+        gmsh.model.mesh.setNode(int(tag), [x, y, z], [])
+    
+    # Generate output filename
+    output_file = Path(f"{args.msh_file.stem}_{args.msh_buffer_length_scale}_{abs(depth)}_{args.msh_element_length_scale}.msh")
+    
+    # Write the mesh to file
+    print(f"Writing output mesh to: {output_file}")
+    gmsh.write(str(output_file))
+    gmsh.finalize()
+    
+    print(f"Successfully created horizontal mesh with {len(coords)} nodes at depth {depth} km")
+
+
+if __name__ == "__main__":
+    main()

--- a/pixi.lock
+++ b/pixi.lock
@@ -485,7 +485,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/addict-2.4.0-pyhd8ed1ab_3.conda
@@ -924,7 +924,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/addict-2.4.0-pyhd8ed1ab_3.conda
@@ -1363,7 +1363,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -1763,7 +1763,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2240,7 +2240,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/addict-2.4.0-pyhd8ed1ab_3.conda
@@ -2670,7 +2670,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/addict-2.4.0-pyhd8ed1ab_3.conda
@@ -3100,7 +3100,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/be/be/3940c9b55cf8faf15dfc6705a35367a889a00a7e313238689921fc2b5cfa/ismember-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -3492,7 +3492,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/c9/010fa37a6b83e6fd6afb9434d9b71d454ad3d420d35205aeb333f0227e65/okada_wrapper-24.6.15.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -6024,10 +6024,10 @@ packages:
   purls: []
   size: 792286
   timestamp: 1752907619396
-- pypi: ./
+- pypi: .
   name: celeri
-  version: 0.0.2.post1.dev406+g24f3679
-  sha256: 7a00014e5597c3744d524508b885310ef78b82aa3ec890907a03e8be834ddeb7
+  version: 0.0.3.post1.dev17+ga43b8ea
+  sha256: b7ee4b4b1c5cadf06d65ec907a4fdcbc9a8cf8c4d533d080458cdafea81c1ad0
   requires_dist:
   - addict
   - cartopy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ celeri-msh2stl = "celeri.scripts.msh2stl:main"
 celeri-stl2msh = "celeri.scripts.stl2msh:main"
 celeri-forward = "celeri.scripts.celeri_forward:main"
 celeri-create-grid-station = "celeri.scripts.create_grid_station:main"
+celeri-create-bel-mesh = "celeri.scripts.create_bel_mesh:main"
 
 
 [project.urls]


### PR DESCRIPTION
@jploveless This is the first draft of a script that will create a BEL mesh below an existing mesh.

The script accepts four command line arguments: 1) The name of a .msh file (`msh_file`), 2) a buffer length scale in km (`msh_buffer_length_scale`), 3) a depth in kilometers (`msh_depth`), and 4) a target mesh element length scale in kilometers (`msh_element_length_scale`).  The core steps are:

- Read the `msh_file` file.
- Find the convex hull around the longitude and latitude coordinates of all mesh elements defined in the `msh_file` 
- Use shapely to buffer the convex hull by a distance `msh_buffer_length_scale`.
- Resample the buffered polygon so that the polygon coordinates are more uniform than the default shaply dense-in-corners-and-sparse-everwhere =-else.
- Use gmsh to mesh the new longitude latitude polygon with a target length scale for mesh elements of `msh_element_length_scale`.
- Set depth of all new mesh nodes to `msh_depth`.
- Write out as a new file with the name formatted as: `<msh_file>_<msh_buffer_length_scale>_<msh_depth>_<msh_element_length_scale>.msh`

As written, this is primarily designed for strike-slip faults, but I did experiment with the Japan mesh because it was readily available.

There's a lot that could be added to this!

Thoughts welcome!

<img width="944" height="915" alt="japen_bel" src="https://github.com/user-attachments/assets/e1809ee4-74c7-41d1-8766-83bb423ed210" />
