### PR TITLE
Debug closure

### DIFF
--- a/celeri/celeri_closure.py
+++ b/celeri/celeri_closure.py
@@ -207,6 +207,51 @@ def _debug_plot_polygons_and_error(
 
     fig, ax = plt.subplots(figsize=(9, 9))
 
+    # Plot all line segments first as thin black lines for context
+    try:
+        for e in range(closure.n_edges()):
+            v1_idx, v2_idx = closure.edge_idx_to_vertex_idx[e]
+            p1 = closure.vertices[v1_idx]
+            p2 = closure.vertices[v2_idx]
+            ax.plot(
+                [p1[0], p2[0]],
+                [p1[1], p2[1]],
+                "-",
+                color="black",
+                linewidth=0.5,
+                zorder=5,
+                label="All segments" if e == 0 else "",
+            )
+
+            # Add original segment index at midpoint in blue
+            # try:
+            #     dx = p2[0] - p1[0]
+            #     if dx > 180:
+            #         dx -= 360
+            #     elif dx < -180:
+            #         dx += 360
+            #     mx = p1[0] + 0.5 * dx
+            #     if mx < 0:
+            #         mx += 360
+            #     elif mx >= 360:
+            #         mx -= 360
+            #     my = 0.5 * (p1[1] + p2[1])
+            #     ax.text(
+            #         mx,
+            #         my,
+            #         str(e),
+            #         color="blue",
+            #         fontsize=8,
+            #         ha="center",
+            #         va="center",
+            #         zorder=12,
+            #     )
+            # except Exception:
+            #     pass
+    except Exception:
+        # Be resilient if any attributes are missing during early failures
+        pass
+
     # Plot all vertices for context
     ax.scatter(
         closure.vertices[:, 0],
@@ -254,16 +299,25 @@ def _debug_plot_polygons_and_error(
             except Exception:
                 nsteps = 0
             if vs_cur.shape[0] >= 2 and nsteps > 0:
-                for j_step in range(min(nsteps, vs_cur.shape[0]-1)):
-                    mx = 0.5*(vs_cur[j_step, 0] + vs_cur[j_step+1, 0])
-                    my = 0.5*(vs_cur[j_step, 1] + vs_cur[j_step+1, 1])
+                for j_step in range(min(nsteps, vs_cur.shape[0] - 1)):
+                    mx = 0.5 * (vs_cur[j_step, 0] + vs_cur[j_step + 1, 0])
+                    my = 0.5 * (vs_cur[j_step, 1] + vs_cur[j_step + 1, 1])
                     ax.text(
-                        mx, my, str(j_step+1),
-                        color='black', fontsize=7,
-                        ha='center', va='center', zorder=31,
-                        bbox=dict(facecolor='white', edgecolor='none', alpha=0.6, boxstyle='round,pad=0.15')
+                        mx,
+                        my,
+                        str(j_step + 1),
+                        color="black",
+                        fontsize=10,
+                        ha="center",
+                        va="center",
+                        zorder=31,
+                        bbox=dict(
+                            facecolor="white",
+                            edgecolor="none",
+                            alpha=0.6,
+                            boxstyle="round,pad=0.15",
+                        ),
                     )
-
 
     # Offending half-edge and its endpoints
     try:

--- a/celeri/celeri_closure.py
+++ b/celeri/celeri_closure.py
@@ -740,26 +740,17 @@ def decompose_segments_into_graph(np_segments):
 def traverse_polygons(closure, right_half_edge):
     # Which polygon lies to the right of the half edge.
     right_polygon = np.full(closure.n_edges() * 2, -1, dtype=int)
-    # print(f"{len(right_polygon)}")
 
     polygon_edge_idxs = []
 
     for half_edge_idx in range(2 * closure.n_edges()):
-        print(f"{half_edge_idx=}")
         # If this half edge is already in a polygon, skip it.
         if right_polygon[half_edge_idx] >= 0:
             continue
 
         # Follow a new polygon around its loop by indexing the right_half_edge array.
         polygon_idx = len(polygon_edge_idxs)
-        print(f"{polygon_idx=}")
-
         polygon_edge_idxs.append([half_edge_idx])
-
-        print(" ")
-        print(f"{polygon_edge_idxs=}")
-        print(" ")
-
         next_idx = right_half_edge[half_edge_idx]
         while next_idx != half_edge_idx:
             # Step 1) Check that we don't have errors!
@@ -774,10 +765,6 @@ def traverse_polygons(closure, right_half_edge):
                     "Geometry problem: unexpected loop found in polygon traversal."
                 )
             if right_polygon[next_idx] != -1:
-                print(f"{closure=}")
-                print(f"{right_polygon=}")
-                print(f"{len(right_polygon)=}")
-                print(f"{next_idx=}")
                 _debug_plot_polygons_and_error(
                     closure,
                     polygon_edge_idxs,

--- a/celeri/celeri_closure.py
+++ b/celeri/celeri_closure.py
@@ -248,6 +248,23 @@ def _debug_plot_polygons_and_error(
                 zorder=30,
             )
 
+            # Annotate traversal order along the in-progress path
+            try:
+                nsteps = len(cur_edges)
+            except Exception:
+                nsteps = 0
+            if vs_cur.shape[0] >= 2 and nsteps > 0:
+                for j_step in range(min(nsteps, vs_cur.shape[0]-1)):
+                    mx = 0.5*(vs_cur[j_step, 0] + vs_cur[j_step+1, 0])
+                    my = 0.5*(vs_cur[j_step, 1] + vs_cur[j_step+1, 1])
+                    ax.text(
+                        mx, my, str(j_step+1),
+                        color='black', fontsize=7,
+                        ha='center', va='center', zorder=31,
+                        bbox=dict(facecolor='white', edgecolor='none', alpha=0.6, boxstyle='round,pad=0.15')
+                    )
+
+
     # Offending half-edge and its endpoints
     try:
         v1_idx, v2_idx = closure.edge_idx_to_vertex_idx[err_half_edge_idx // 2]


### PR DESCRIPTION
This adds some plotting related to block closure to identify geographically where problems are arising.  This helped me find a ton of error cases that emerged from the initial WNA models.  These include:

- zero dip cases (autofixable)
- vertical segments (autofixable)
- pure horizontal segments (autofixable)
- zero-length segments (autofixable)
- hanging segments (celer_ui fixable)
- duplicate segments (autofixable)
- lon1, lat1, lon2, lat2, not terminating at 3 digits (autofixable)...this one took forever to figure out.

I'm working on a more general script that identifies these issues and autofixes where appropriate.

@jploveless Just for reference.