### PR TITLE
Adding verbose output to clarabel solver.

### DIFF
--- a/celeri/optimize.py
+++ b/celeri/optimize.py
@@ -1203,6 +1203,7 @@ def solve_sqp2(
         "solver": "CLARABEL",
         "ignore_dpp": True,
         "warm_start": False,
+        "verbose": True,
     }
 
     if solve_kwargs is not None:


### PR DESCRIPTION
@aseyboldt I'm adding `"verbose": True` to the CVXPY solver.  With some additional constraints in the WNA model, the solver throws the warning below:

```
/Users/meade/Desktop/celeri-org/celeri/.pixi/envs/default/lib/python3.13/site-packages/cvxpy/problems/problem.py:1539: UserWarning: Solution may be inaccurate. Try another solver, adjusting the solver settings, or solve with verbose=True for more information.
  warnings.warn(
```

The verbose output reveals that this is **only** emerging from the first SQP iteration.  That's good news.

@aseyboldt I would like to ask you for help/guidance here.  Specifically, I'd like the output to note which iterations this warning emerges from.  That would help us determine if it's a warning worth worrying about (in the last iteration) or something that goes away after the first iteration.  

Thoughts!
