### PR TITLE
Switch pixi.toml from [project] to [workspace]

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 # It is equivalent to the `environment.yml`. The environment can be activated
 # with the command `pixi shell`.
 
-[project]
+[workspace]
 name = "celeri"
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 channels = ["conda-forge"]


### PR DESCRIPTION
This is a super-minor maintenance update.

If you encounter an error after this is merged, then you need to update pixi:

```bash
pixi self-update
```

Pixi has treated `pixi.toml` as a workspace manifest since 0.43.0, and as of 0.57.0 it explicitly deprecates the `[project]` table in favor of `[workspace]`, emitting warnings when the old name is used. Updating our manifest removes those warnings.

<https://pixi.sh/dev/CHANGELOG/#0430-2025-03-20>