### PR TITLE
Fix syntax error in check-lockfile workflow

### DIFF
--- a/.github/workflows/check-lockfile.yaml
+++ b/.github/workflows/check-lockfile.yaml
@@ -122,6 +122,7 @@ jobs:
                 echo "We regenerated \`pixi.lock\` and verified it merges cleanly with \`$BASE_REF\`."
               fi
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Fail to block merge
         if: steps.lockfile-status.outputs.stale == 'true'
         run: |


### PR DESCRIPTION
I'm disappointed that Copilot didn't catch this, given all the times I ran it.