### PR TITLE
Allow tests to proceed with a stale lockfile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           cache: true
           environments: ${{ matrix.pixi-environment }}
+          # The lockfile is allowed to be a lie
+          locked: false
+          # If the lockfile is a lie, then defer to pixi.toml as the source of truth
+          # over the lockfile, and locally overwrite the lockfile accordingly.
+          frozen: false
       - name: Test
         if: ${{ matrix.tests-to-run == 'other' }}
         run: |


### PR DESCRIPTION
@brendanjmeade, I hope this particular PR will be a major improvement to a particular pain point.

Before: when the lockfile is stale, all tests immediately fail because pixi in CI refuses to install an inconsistent lockfile

After: the tests proceed, despite the inconsistent lockfile. To resolve the inconsistency, the lockfile is locally updated on the runner so that the tests can proceed.

This way, we still get a clear warning when the lockfile is inconsistent via the `check-lockfile` workflow. But if need be, we can ignore the `check-lockfile` error and still ensure test coverage, preventing the PR from being fully blocked.