### PR TITLE
Fix lockfile alert script checkout handling

### DIFF
--- a/.github/scripts/lockfile-alert-check.sh
+++ b/.github/scripts/lockfile-alert-check.sh
@@ -15,14 +15,14 @@ if [[ -z "${PR_NUMBER}" || -z "${BASE_REF}" ]]; then
   exit 2
 fi
 
-TMP_BRANCH="lockfile-alert/pr-${PR_NUMBER}"
+PR_HEAD="refs/pull/${PR_NUMBER}/head"
 REMOTE_BASE="origin/${BASE_REF}"
 
 git fetch --no-tags --depth=1 origin "${BASE_REF}"
-git fetch --no-tags origin "pull/${PR_NUMBER}/head:${TMP_BRANCH}"
-git checkout -B "${TMP_BRANCH}" "${TMP_BRANCH}"
+git fetch --no-tags --depth=1 origin "${PR_HEAD}"
 
-if git diff --quiet HEAD.."${REMOTE_BASE}" -- pixi.lock; then
+# Compare pixi.lock between PR head and base without checking out
+if git diff --quiet "${PR_HEAD}" "${REMOTE_BASE}" -- pixi.lock; then
   result=false
 else
   result=true

--- a/.github/workflows/lockfile-alert.yaml
+++ b/.github/workflows/lockfile-alert.yaml
@@ -24,9 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          # pull_request_target jobs run with secrets from the base repo; keep execution
-          # on the base branch explicitly to avoid running untrusted PR code.
-          ref: ${{ github.event.pull_request.base.ref }}
+          # pull_request_target runs in the base repo context with access to secrets.
+          # Explicitly check out the default branch so we always execute the latest
+          # trusted workflow helpers, not PR code or an outdated base commit.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Detect pixi.lock drift


### PR DESCRIPTION
Sorry for all the noise, I'm not aware of a better way to iterate on GitHub Actions workflows.