### PR TITLE
bug fix for write_output

### DIFF
--- a/celeri/output.py
+++ b/celeri/output.py
@@ -61,7 +61,6 @@ def write_output(
                 mesh_data[field_name] = mesh_config[field_name]
 
             for key, value in mesh_data.items():
-                print(key, value)
                 if value is None:
                     continue
                 if isinstance(value, str):


### PR DESCRIPTION
Addresses issue #312. The bug had to do with the fact that not every mesh always has an associated entry in `estimation.tde_strike_slip_rates_kinematic`. This traces back to lines 1184-1200 in `operators.py`, where only meshes that are tied to fault segments are given entries in the operator `rotation_to_tri_slip_rate`.