### PR TITLE
feat: Add option to project onto eigenbasis in mcmc

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -174,7 +174,17 @@ class Config(BaseModel):
 
     # Parameters of mcmc
     mcmc_tune: int | None = 1000
+    """Number of tuning steps in MCMC before sampling."""
+
     mcmc_draws: int | None = None
+    """Number of MCMC samples to draw after tuning."""
+
+    mcmc_chains: int = 1
+    """Number of parallel MCMC chains to run."""
+
+    mcmc_backend: Literal["numba", "jax"] = "numba"
+    """Backend to use for MCMC computations."""
+
     mcmc_station_velocity_method: McmcStationVelocityMethod = "project_to_eigen"
     """Method for computing station velocities from slip rates in MCMC.
 
@@ -183,6 +193,7 @@ class Config(BaseModel):
     - "low_rank": Low rank approximation of TDE-to-station operator via SVD
     - "project_to_eigen": Project slip rates onto eigenbasis before computing velocities (default)
     """
+
     mcmc_station_weighting: McmcStationWeighting | None = "voronoi"
     """Method for weighting station observations in MCMC likelihood.
 

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -660,13 +660,13 @@ def solve_mcmc(
 
     compiled = nutpie.compile_pymc_model(
         pymc_model,
-        backend="numba",
+        backend=model.config.mcmc_backend,
     )
     kwargs = {
         "low_rank_modified_mass_matrix": True,
         "mass_matrix_eigval_cutoff": 1.5,
         "mass_matrix_gamma": 1e-6,
-        "chains": 1,
+        "chains": model.config.mcmc_chains,
         "draws": model.config.mcmc_draws,
         "tune": model.config.mcmc_tune,
         "store_unconstrained": True,


### PR DESCRIPTION
This implements projecting the transformed elastic velocities onto the eigenbasis as discussed in #314, and includes a little bit of refactoring of the mcmc solver.

Probably easiest to review the commits one at a time.

A new config item controls which projection to use:

```
    mcmc_station_velocity_method: McmcStationVelocityMethod = "project_to_eigen"
    """Method for computing station velocities from slip rates in MCMC.

    Options:
    - "direct": Direct multiplication with TDE-to-station operator
    - "low_rank": Low rank approximation of TDE-to-station operator via SVD
    - "project_to_eigen": Project slip rates onto eigenbasis before computing velocities (default)
```

With the projection onto the eigen basis the sampler runs in about 10 minutes on the wna dataset. (Down from ~30 minutes with the low_rank svd approach).

I haven't looked all that closely into differences in the solution yet, from a quick look they don't seem huge, but also clearly not zero...