### PR TITLE
Added mesh_param editing script

### DIFF
--- a/celeri/scripts/apply_mesh_params.py
+++ b/celeri/scripts/apply_mesh_params.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# %%
+
+import argparse
+import json
+from pathlib import Path
+
+import celeri
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "template_file_name",
+        type=Path,
+        help="Name of template mesh_param file.",
+    )
+
+    parser.add_argument(
+        "destination_file_name",
+        type=Path,
+        help="Name of mesh_param file to be updated.",
+    )
+
+    parser.add_argument(
+        "--start_idx",
+        "-s",
+        type=int,
+        default="0",
+        help="Starting index to apply parameters",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--end_idx",
+        "-e",
+        type=int,
+        default="-1",
+        help="Ending index to apply parameters",
+        required=False,
+    )
+
+    args = dict(vars(parser.parse_args()))
+    start_idx = int(args["start_idx"])
+    end_idx = int(args["end_idx"])
+
+    # Read template and destination files
+    template = celeri.MeshConfig.from_file(args["template_file_name"])
+    destination = celeri.MeshConfig.from_file(args["destination_file_name"])
+
+    # Define the last dict entry to be changed
+    range_end = len(destination) + end_idx + 1
+    # For each set of mesh_params to be changed
+    for i in range(start_idx, range_end):
+        # For each mesh_param in the template list (except filenames)
+        for name in type(template[0]).model_fields:
+            if (name != "file_name") & (name != "mesh_filename"):
+                template_value = getattr(template[0], name)
+                setattr(destination[i], name, template_value)
+
+    # Write the updated destination file
+    data = [mesh_config.model_dump(mode="json") for mesh_config in destination]
+    with args["destination_file_name"].open("w") as destination_file:
+        json.dump(data, destination_file, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/celeri/scripts/create_mesh_params_template.py
+++ b/celeri/scripts/create_mesh_params_template.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# %%
+
+import argparse
+import json
+from pathlib import Path
+
+import celeri
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "template_file_name",
+        type=Path,
+        default=Path("template_mesh_params.json"),
+        help="Name of template mesh_param file.",
+        nargs="?",
+    )
+
+    args = dict(vars(parser.parse_args()))
+
+    # Get default mesh_params from MeshConfig in mesh.py
+    template = celeri.MeshConfig(file_name=args["template_file_name"])
+
+    # Write template file
+
+    # Create json dump as a list of length one, to agree with what celeri.mesh.from_file expects
+    data = [template.model_dump(mode="json")]
+    with args["template_file_name"].open("w") as template_file:
+        json.dump(data, template_file, indent=4)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR contains 2 little scripts: 

1. `apply_mesh_params.py` uses a template `mesh_param.json` file and applies those parameters to a separate, destination file. The standard usage is: 

`python apply_mesh_params.py template_mesh_params.json destination_mesh_params.json`

where `template_mesh_params.json` contains a one-item list of mesh parameters to be applied to all mesh entries in a longer, existing mesh parameter file, `destination_mesh_params.json`. 

To apply the mesh parameters to a sequential subset of meshes in the destination file (useful for applying to the parameter file created by `segmesh.py`), use: 

`python apply_mesh_params.py template_mesh_params.json destination_mesh_params.json -s 1 -e -2`

The above usage will apply the template mesh parameters to meshes with index 1 through -2 (second through second to last). A case for this might be a Western U.S. model with segment ribbon meshes, where the Cascadia mesh is mesh 0, a CMI mesh is the final mesh (index -1), and `segmesh`-generated meshes lie in between; the Cascadia and CMI meshes may need very different parameters than a uniform set applied to all `segmesh`-generated meshes. 

2. `create_mesh_params_template.py` creates a new `.json` file, grabbing the default mesh parameters from `mesh.py`. This file can then be edited manually and serve as the input template for `apply_mesh_params.py`. To use, either just call it with no arguments (which will create `template_mesh_params.json` in the current directory, or specify the path to an output file. 