### PR TITLE
Fix lockfile alert to use merge-base comparison

### DIFF
--- a/.github/scripts/lockfile-alert-check.sh
+++ b/.github/scripts/lockfile-alert-check.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-# Determine whether pixi.lock differs between a PR head and its base branch.
+# Determine whether the base branch has pixi.lock changes that the PR hasn't
+# incorporated yet. Uses merge-base comparison: if the base branch's lockfile
+# differs from the merge-base, the PR needs to rebase/merge.
+#
 # Arguments:
 #   1: PR number
 #   2: Base branch ref (e.g., main)
@@ -17,13 +20,20 @@ fi
 
 REMOTE_BASE="origin/${BASE_REF}"
 
-git fetch --no-tags --depth=1 origin "${BASE_REF}"
-git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:pr-${PR_NUMBER}"
+# Fetch refs needed for merge-base calculation.
+# - Base ref might be missing if PR targets a non-default branch
+# - PR ref (refs/pull/N/head) is never auto-fetched by actions/checkout
+git fetch --no-tags origin "${BASE_REF}"
+git fetch --no-tags origin "pull/${PR_NUMBER}/head:pr-${PR_NUMBER}"
 
-# Compare pixi.lock between PR head and base without checking out
+# Find the common ancestor between PR and base
+MERGE_BASE=$(git merge-base "pr-${PR_NUMBER}" "${REMOTE_BASE}")
+
+# Check if base branch has lockfile changes since the merge-base.
+# If so, the PR needs to incorporate those changes.
 # git diff --quiet exits 0 if no diff, 1 if diff exists, >1 on error
 set +e
-git diff --quiet "pr-${PR_NUMBER}" "${REMOTE_BASE}" -- pixi.lock
+git diff --quiet "${MERGE_BASE}" "${REMOTE_BASE}" -- pixi.lock
 diff_status=$?
 set -e
 
@@ -34,12 +44,20 @@ fi
 
 if [[ ${diff_status} -eq 0 ]]; then
   result=false
+  lockfile_commit=""
 else
   result=true
+  # Get the most recent commit on base branch that modified pixi.lock
+  lockfile_commit=$(git log -1 --format='%H' "${MERGE_BASE}..${REMOTE_BASE}" -- pixi.lock)
 fi
+
+# Output results (always echo for debugging, write to GITHUB_OUTPUT if available)
+echo "needs_alert=${result}"
+echo "merge_base=${MERGE_BASE}"
+echo "lockfile_commit=${lockfile_commit}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "needs_alert=${result}" >> "${GITHUB_OUTPUT}"
-else
-  echo "needs_alert=${result}"
+  echo "merge_base=${MERGE_BASE}" >> "${GITHUB_OUTPUT}"
+  echo "lockfile_commit=${lockfile_commit}" >> "${GITHUB_OUTPUT}"
 fi

--- a/.github/scripts/lockfile-alert-comment.js
+++ b/.github/scripts/lockfile-alert-comment.js
@@ -5,6 +5,8 @@
  *
  * Environment variables:
  *   NEEDS_ALERT - "true" if alert should be posted/updated, "false" to minimize
+ *   MERGE_BASE - Merge base commit SHA
+ *   LOCKFILE_COMMIT - Most recent commit that modified pixi.lock on base branch
  *   PR_NUMBER - Pull request number
  *   BASE_REF - Base branch reference (e.g., "main")
  *   AUTHOR - PR author's GitHub username
@@ -17,6 +19,8 @@ const https = require('https');
 const MARKER = '<!-- lockfile-alert -->';
 
 const needsAlert = (process.env.NEEDS_ALERT || '').toLowerCase() === 'true';
+const mergeBase = process.env.MERGE_BASE || '';
+const lockfileCommit = process.env.LOCKFILE_COMMIT || '';
 const prNumber = Number(process.env.PR_NUMBER);
 const baseRef = process.env.BASE_REF;
 const headRef = process.env.HEAD_REF;
@@ -47,7 +51,7 @@ if (headRepo && baseRepo && headRepo !== baseRepo) {
 const alertBody = `${MARKER}
 Hi @${author},
 
-\`${baseRef}\` has updated \`pixi.lock\` since this branch was last synced. Merge or rebase the latest \`${baseRef}\` so dependency metadata stays current.${remoteContext}
+\`${baseRef}\` has updated \`pixi.lock\` since this branch was last synced (merge-base: ${mergeBase}, latest lockfile change: ${lockfileCommit}). Merge or rebase the latest \`${baseRef}\` so dependency metadata stays current.${remoteContext}
 
 \`\`\`bash
 git checkout ${headRef}

--- a/.github/workflows/lockfile-alert.yaml
+++ b/.github/workflows/lockfile-alert.yaml
@@ -51,6 +51,8 @@ jobs:
       - name: Update alert comment
         env:
           NEEDS_ALERT: ${{ steps.detect.outputs.needs_alert }}
+          MERGE_BASE: ${{ steps.detect.outputs.merge_base }}
+          LOCKFILE_COMMIT: ${{ steps.detect.outputs.lockfile_commit }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -118,6 +120,8 @@ jobs:
       - name: Update alert comment
         env:
           NEEDS_ALERT: ${{ steps.detect.outputs.needs_alert }}
+          MERGE_BASE: ${{ steps.detect.outputs.merge_base }}
+          LOCKFILE_COMMIT: ${{ steps.detect.outputs.lockfile_commit }}
           PR_NUMBER: ${{ matrix.pr.number }}
           BASE_REF: ${{ matrix.pr.baseRef }}
           HEAD_REF: ${{ matrix.pr.headRef }}


### PR DESCRIPTION
The previous logic alerted whenever pixi.lock differed between PR and base, which incorrectly triggered alerts when the PR legitimately updated the lockfile.

Now uses merge-base comparison: only alerts when the base branch has lockfile changes since the common ancestor, indicating the PR needs to incorporate those changes via merge/rebase.

Also includes the merge-base and latest lockfile commit in the PR comment for better context.