### PR TITLE
minor: lockfile-alert: remove backticks from SHAs for GitHub auto-linking

### DIFF
--- a/.github/scripts/lockfile-alert-comment.js
+++ b/.github/scripts/lockfile-alert-comment.js
@@ -66,7 +66,7 @@ git fetch ${remoteName}
 git merge ${remoteName}/${baseRef}
 \`\`\`
 
-Merge-base: \`${mergeBase}\`, latest lockfile change on \`${baseRef}\`: \`${lockfileCommit}\`.
+Merge-base: ${mergeBase}, latest lockfile change on \`${baseRef}\`: ${lockfileCommit}.
 
 This notice will be minimized automatically once \`pixi.lock\` on \`${baseRef}\` matches the merge-base.
 
@@ -97,7 +97,7 @@ git add pixi.lock
 git merge --continue
 \`\`\`
 
-Merge-base: \`${mergeBase}\`, latest lockfile change on \`${baseRef}\`: \`${lockfileCommit}\`.
+Merge-base: ${mergeBase}, latest lockfile change on \`${baseRef}\`: ${lockfileCommit}.
 
 This alert will be minimized automatically once \`pixi.lock\` conflicts are resolved.
 


### PR DESCRIPTION
improves formatting