### PR TITLE
Fix version detection error when running from Jupyter

### DIFF
--- a/celeri/version.py
+++ b/celeri/version.py
@@ -39,10 +39,17 @@ def _get_hatch_version():
     pyproject_toml = locate_file(__file__, "pyproject.toml")
     if pyproject_toml is None:
         raise RuntimeError("pyproject.toml not found although hatchling is installed")
-    root = str(Path(pyproject_toml).parent)
-    metadata = ProjectMetadata(root=root, plugin_manager=PluginManager())
-    # Version can be either statically set in pyproject.toml or computed dynamically:
-    return metadata.core.version or metadata.hatch.version.cached
+    root = Path(pyproject_toml).parent
+
+    # Temporarily set cwd to project root for PEP 517 compliance.
+    old_cwd = Path.cwd()
+    os.chdir(root)
+    try:
+        metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
+        # Version can be static in pyproject.toml or computed dynamically:
+        return metadata.core.version or metadata.hatch.version.cached
+    finally:
+        os.chdir(old_cwd)
 
 
 def _get_importlib_metadata_version():


### PR DESCRIPTION
Fixes an occasional `ConfigurationError: ["Fragment file 'README.md' not found."]` when determining the current version and Git commit from Jupyter notebooks.

See maresb/hatch-vcs-footgun-example#13