### PR TITLE
Added option to apply two templates based on dip

### DIFF
--- a/celeri/scripts/apply_mesh_params.py
+++ b/celeri/scripts/apply_mesh_params.py
@@ -87,11 +87,12 @@ def main():
         with args["destination_file_name"].open("w") as destination_file:
             json.dump(data, destination_file, indent=4)
     else:
-        # If so, need to read in the mesh and check its geometry
-        # For each set of mesh_params to be changed
+        # If so, load the alternate template
         alt_template = celeri.MeshConfig.from_file(args["alt_template"])
+        # Need to read in the meshes and check their geometry
         meshes = []
         meshes = [celeri.Mesh.from_params(mesh_param) for mesh_param in destination]
+        # For each set of mesh_params to be changed
         for i in range(start_idx, range_end):
             this_mesh = meshes[i]
             # Check the dip threshold


### PR DESCRIPTION
@brendanjmeade This PR modifies `apply_mesh_params.py` to allow optional specification of a second template file whose parameters are applied to meshes with average element dip above a threshold. It's a bit clunky with the optional command line arguments, so please let me know if you have different suggestions. Usage is as follows: 

- Create two `*mesh.json` parameter files, one for shallowly dipping faults and one for steeply dipping
- Call `apply_mesh_params.py` as follows: 

```
python apply_mesh_params.py template_shallow.json destination_mesh_param.json --start_idx 3 --alt_template template_steep.json --dip_threshold 85
```

The default dip threshold is 89º (but optionally specified a little shallower here), and the threshold checking is done using absolute value, since some dips are reported as >90º. 