### PR TITLE
Add pre-commit janitor workflow

### DIFF
--- a/.github/scripts/pre-commit-janitor-commit.sh
+++ b/.github/scripts/pre-commit-janitor-commit.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Create the first commit for pre-commit autofixes and prepare .git-blame-ignore-revs.
+#
+# This script:
+#   1. Checks if there are any staged/unstaged changes
+#   2. Creates a commit with all changes ("pre-commit autofix")
+#   3. Appends the commit hash to .git-blame-ignore-revs (leaves it uncommitted
+#      for peter-evans/create-pull-request to commit)
+#
+# Outputs:
+#   - has_changes: "true" if changes were committed, "false" otherwise
+
+set -euo pipefail
+
+# Check for changes
+if git diff --quiet && git diff --cached --quiet; then
+  echo "No changes from pre-commit autofixes"
+  echo "has_changes=false"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+  fi
+  exit 0
+fi
+
+echo "Pre-commit made changes, creating commit..."
+
+# Configure git identity
+git config user.name "pre-commit-janitor.yaml"
+git config user.email "nobody@example.com"
+
+# Create commit with all autofixes
+git add -A
+git commit -m "pre-commit autofix"
+AUTOFIX_COMMIT=$(git rev-parse HEAD)
+echo "Created autofix commit: ${AUTOFIX_COMMIT}"
+
+# Append to .git-blame-ignore-revs (create if it doesn't exist)
+# Leave uncommitted for peter-evans/create-pull-request to handle
+if [[ ! -f .git-blame-ignore-revs ]]; then
+  cat > .git-blame-ignore-revs <<'EOF'
+# This file lists revisions that should be ignored when blaming a file.
+# It should include all substantial machine-generated reformatting commits.
+EOF
+else
+  echo "" >> .git-blame-ignore-revs
+fi
+{
+  echo "# pre-commit autofix"
+  echo "${AUTOFIX_COMMIT}"
+} >> .git-blame-ignore-revs
+echo "Updated .git-blame-ignore-revs"
+
+# Output results
+echo "has_changes=true"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/workflows/pre-commit-janitor.yaml
+++ b/.github/workflows/pre-commit-janitor.yaml
@@ -1,0 +1,65 @@
+name: Pre-commit Janitor
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+  # At 06:38 UTC on Sundays
+  - cron: 38 6 * * 0
+
+jobs:
+  pre-commit-janitor:
+    runs-on: ubuntu-latest
+    environment: create-pr
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        fetch-depth: 0
+    - name: Set up pixi
+      uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
+      with:
+        cache: true
+    - name: Run pre-commit autofixes
+      run: |
+        # Run pre-commit on all files; ignore exit code since we only want the autofixes
+        pixi run pre-commit run --all-files || true
+    - name: Create autofix commit and update blame-ignore
+      id: commit
+      run: bash "${GITHUB_WORKSPACE}/.github/scripts/pre-commit-janitor-commit.sh"
+    - name: Open a pull request
+      if: steps.commit.outputs.has_changes == 'true'
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+      id: create-pr
+      with:
+        token: ${{ secrets.GH_PAT_FOR_PR }}
+        commit-message: Add pre-commit autofix commit to .git-blame-ignore-revs
+        title: pre-commit autofix
+        body: |
+          This pull request applies pre-commit autofixes to the codebase.
+
+          It is triggered by [pre-commit-janitor](https://github.com/brendanjmeade/celeri/blob/main/.github/workflows/pre-commit-janitor.yaml).
+        branch: pre-commit-janitor
+        delete-branch: true
+        assignees: ${{ github.event_name == 'schedule' && 'brendanjmeade' || '' }}
+        committer: pre-commit-janitor.yaml <nobody@example.com>
+        author: pre-commit-janitor.yaml <nobody@example.com>
+        add-paths: .git-blame-ignore-revs
+    - name: Ping @brendanjmeade
+      # The above PAT runs under the context of a personal access token, and thus
+      # doesn't generate notifications for the token's owner. We get around this by
+      # instead using the default token to write a comment in the PR.
+      # Ref: <https://stackoverflow.com/a/78238780>
+      if: github.event_name == 'schedule' && contains('created,updated', steps.create-pr.outputs.pull-request-operation)
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: ${{ steps.create-pr.outputs.pull-request-number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'ping @brendanjmeade'
+          })


### PR DESCRIPTION
Runs weekly on Sundays at 06:38 UTC (or via workflow_dispatch) to apply pre-commit autofixes. Creates two commits: one with the fixes, and one adding that commit to .git-blame-ignore-revs.