### PR TITLE
drop full_dense_operator access in _state_vector_from_draw

### DIFF
--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -769,7 +769,7 @@ def _state_vector_from_draw(
 ):
     assert operators_tde.tde is not None
     assert operators_tde.index.tde is not None
-    n_params = operators_tde.full_dense_operator.shape[1]
+    n_params = operators_tde.index.n_operator_cols
     state_vector = np.zeros(n_params)
 
     start = operators_tde.index.start_block_strain_col


### PR DESCRIPTION
This will likely need further engineering once we have Estimation objects to deal with for the new WNA
