### PR TITLE
(don't merge) Vectorize meshes

### DIFF
--- a/celeri/operators.py
+++ b/celeri/operators.py
@@ -2276,7 +2276,7 @@ def _compute_eigen_to_velocities(
     for i in range(index.n_meshes):
         if streaming:
             logger.info(
-                f"Start: Streaming eigen_to_velocities for mesh: {meshes[i].file_name}"
+                f"Loading eigen_to_velocities for mesh: {meshes[i].file_name}"
             )
 
             tde_to_velocities = None


### PR DESCRIPTION
@aseyboldt something like this to take the model roughly from 

<img width="589" height="866" alt="Screenshot 2026-01-25 at 8 35 09 PM" src="https://github.com/user-attachments/assets/c09273f2-bec9-4e9e-8bd3-8772825798e6" />

to 

<img width="1120" height="749" alt="Screenshot 2026-01-25 at 8 35 41 PM" src="https://github.com/user-attachments/assets/f8aa5b4b-10f6-43c8-89e1-0c3ea9bdc0b6" />

I advocate for removing all tde-level things from the model altogether and just rebuild everything post hoc. Except for in the coupling-constrained case I guess we need to construct the elastic fields to do coupling_coefs -> coupling_field -> elastic_field -> velocities. I'd also propose we finish Matern before doing this