### PR TITLE
Better calculation of mean mesh dip

### DIFF
--- a/celeri/scripts/apply_mesh_params.py
+++ b/celeri/scripts/apply_mesh_params.py
@@ -94,7 +94,6 @@ def main():
         meshes = [celeri.Mesh.from_params(mesh_param) for mesh_param in destination]
         # For each set of mesh_params to be changed
         for i in range(start_idx, range_end):
-            meshes[i]
             # Check the dip threshold
             # If the mesh's mean element dip is greater than the threshold
             # Taking the mean as the magnitudes of the deviation from 90, so that dips expressed > 90 don't bias mean


### PR DESCRIPTION
@brendanjmeade Quick fix here to how the average mesh dip is calculated, when deciding which parameter template to apply. 

Elements can have reported dips > 90º, and so a mean of mix of elements > 90º and < 90º will be "biased steep." The new approach calculates the mean of the absolute value of the deviation from 90º as the basis for the threshold. It does seem that plenty of WNA meshes will have the other template applied after this fix. I'm not sure how much this will matter in practice, but this does seem like a more geometrically accurate way of calculating mesh steepness. 