### PR TITLE
Fix typos in operators docstring and notebook heading

### DIFF
--- a/celeri/operators.py
+++ b/celeri/operators.py
@@ -1368,7 +1368,7 @@ def _store_tde_slip_rate_constraints(model: Model, operators: _OperatorBuilder):
     as controlled by input parameters
     top_slip_rate_constraint,
     bot_slip_rate_constraint,
-    side_slip_rate_constraint,.
+    side_slip_rate_constraint,
 
     and at other elements with indices specified as
     ss_slip_constraint_idx,
@@ -1926,7 +1926,7 @@ def _get_weighting_vector_eigen(model: Model, index: Index) -> np.ndarray:
 
     # TODO: Need to think about constraints weights
     # This is the only place where any individual constraint weights enter
-    # I'm only using on of them: meshes[i].bot_slip_rate_weight
+    # I'm only using one of them: meshes[i].bot_slip_rate_weight
     for i in range(len(model.meshes)):
         weighting_vector[
             index.eigen.start_tde_constraint_row_eigen[

--- a/notebooks/doc_resolution_test.ipynb
+++ b/notebooks/doc_resolution_test.ipynb
@@ -441,7 +441,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Experiment: constrainted least squares\n",
+    "# Experiment: constrained least squares\n",
     "- The idea is to constrain TDE slip rates in some region"
    ]
   },


### PR DESCRIPTION
## Summary

Split from #414.

- Fix trailing period typo in `_store_tde_slip_rate_constraints` docstring
- Fix "on" -> "one" typo in `_get_weighting_vector_eigen` comment
- Fix "constrainted" -> "constrained" in `doc_resolution_test.ipynb` heading

Made with [Cursor](https://cursor.com)