### PR TITLE
Made model.config.mesh_params empty in segmesh.py

### DIFF
--- a/celeri/scripts/segmesh.py
+++ b/celeri/scripts/segmesh.py
@@ -490,13 +490,14 @@ def main():
     model.config.segment_file_name = Path(new_segment_file_name)
     # Reference new mesh parameter file, including newly created meshes
     model.config.mesh_parameters_file_name = Path(new_mesh_param_name)
-    # Strip mesh params from config, because if we need to edit params, we want to do so in one place (*mesh_params_segmesh.json)
-    model.config.mesh_params = []
 
     # Express paths relative to the config file directory
     config_dir = new_config_file_name.parent.resolve()
     context = {"paths_relative_to": config_dir}
-    data = model.config.model_dump(mode="json", context=context)
+    # Excluse mesh_params attribute, because we likely want to set those later using apply_mesh_params
+    data = model.config.model_dump(
+        mode="json", context=context, exclude={"mesh_params"}
+    )
     with new_config_file_name.open("w") as cf:
         json.dump(data, cf, indent=4)
 


### PR DESCRIPTION
When running `segmesh.py` from #427, I got the error: 

```
pydantic_core._pydantic_core.PydanticSerializationError: Error calling function `_relative_path_context`: AttributeError: 'Config' object has no attribute 'mesh_params'
```

because I had used `delattr(model.config, "mesh_params")` to remove the `mesh_params` attribute from the `Config` object. My rationale for this is that we want to just be able to change mesh parameters in a single place (the standalone mesh parameter file also written by `segmesh.py`, usually by using `apply_mesh_params.py`), rather than having confusion by having them differ between the standalone file and those embedded within the main config file. 

This PR gets around this error by just setting `model.config.mesh_params = []`. This seems to be fine: the code runs, and the resulting `*_config_segmesh.json` includes relative paths, and a pointer to the correct standalone mesh parameter file, and it allows for proper construction of a model with `celeri.build_model`. But is setting the `mesh_params` attribute to empty bad practice (Pylance wasn't happy about `None` or `null`), and if so, is there a good alternative?  