### PR TITLE
Add examples for plotting posterior stdevs

### DIFF
--- a/notebooks/doc_matplotlib_vis.ipynb
+++ b/notebooks/doc_matplotlib_vis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -259,7 +259,7 @@
    },
    "outputs": [],
    "source": [
-    "estimation = celeri.Estimation.from_disk(\"../../wna/runs/0000000040/\")"
+    "estimation = celeri.Estimation.from_disk(\"../../wna/runs/0000000045/\")"
    ]
   },
   {
@@ -893,6 +893,61 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Posterior standard deviations of slip rates on meshes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "stds = {}\n",
+    "kind=\"ss\"\n",
+    "\n",
+    "for mesh_idx in range(len(estimation.model.meshes)):\n",
+    "    name = f\"coupling_{mesh_idx}_{kind}\"\n",
+    "    if name in estimation.mcmc_trace.posterior:\n",
+    "        stds[mesh_idx] = float(estimation.mcmc_trace.posterior[name].std([\"chain\", \"draw\"]).min().values)\n",
+    "\n",
+    "print(f\"Average standard deviation of slip rates on meshes with {kind}: \\n\", pd.Series(stds))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get MCMC standard deviations for a mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from celeri.plot import plot_mesh\n",
+    "\n",
+    "mesh_idx = 0\n",
+    "type = \"kinematic\"\n",
+    "slip_comp = \"ds\"\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 1, figsize=(12, 6))\n",
+    "\n",
+    "pc = plot_mesh(estimation.model.meshes[mesh_idx],\n",
+    "    fill_value=estimation.mcmc_trace.posterior[f\"{type}_{mesh_idx}_{slip_comp}\"].isel(chain=0).std(dim=\"draw\"),\n",
+    "    ax=axes,\n",
+    "    set_limits=True,\n",
+    ")\n",
+    "fig.colorbar(pc, ax=axes, label=\"Coupling posterior std\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Fault slip rates (strike-slip)"
    ]
   },
@@ -1336,7 +1391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.13.11"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Adding to `doc_matplotlib_vis.ipynb` examples for how to see a) standard deviations of slip/coupling rates on a mesh (_given_ a draw or aggregation of draws), and b) MCMC standard deviations _between_ draws, on the tde-level.