### PR TITLE
Fix pre-commit janitor failing when no autofixes are needed

### DIFF
--- a/.github/workflows/pre-commit-janitor.yaml
+++ b/.github/workflows/pre-commit-janitor.yaml
@@ -52,7 +52,7 @@ jobs:
       # doesn't generate notifications for the token's owner. We get around this by
       # instead using the default token to write a comment in the PR.
       # Ref: <https://stackoverflow.com/a/78238780>
-      if: github.event_name == 'schedule' && contains('created,updated', steps.create-pr.outputs.pull-request-operation)
+      if: github.event_name == 'schedule' && steps.create-pr.outputs.pull-request-number && contains('created,updated', steps.create-pr.outputs.pull-request-operation)
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The "Ping" step in the Pre-commit Janitor workflow crashes with a `SyntaxError` whenever pre-commit finds no changes to autofix (3 of the last 5 scheduled runs failed this way).
- Root cause: when the `create-pr` step is skipped, its outputs are empty strings. `contains('created,updated', '')` evaluates to `true` (empty string is a substring of everything), so the ping step runs with an empty `issue_number`, producing invalid JavaScript.
- Fix: add a `steps.create-pr.outputs.pull-request-number` truthiness guard to the `if` condition so the step is skipped when no PR was created.

Made with [Cursor](https://cursor.com)