### PR TITLE
Fix Weyl length scale estimates

### DIFF
--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -904,10 +904,14 @@ def _log_eigenvalue_truncation(
             and diameter is not None
             and matern_length_units is not None
         )
+        # Cap the correction at 1.0 for ℓ estimates: when the mesh is
+        # underprovisioned (C < 1), the correction was calibrated far from
+        # the Weyl regime and degrades the estimate at larger ℓ.
+        ell_correction = max(correction, 1.0)
         ell_parts = []
         for t in thresholds:
             abs_ell = _weyl_length_scale_estimate(
-                nu, total_area, n_modes, 1 - t, correction
+                nu, total_area, n_modes, 1 - t, ell_correction
             )
             if matern_length_units == "diameters":
                 ell_parts.append(f"ℓ({t:.1%})≈{abs_ell / diameter:.2g}⌀")


### PR DESCRIPTION
## Summary

- Format ℓ estimates with 2 significant figures (`.2g`) so that e.g. `ℓ(99.0%)≈0.024⌀` instead of `ℓ(99.0%)≈0.02⌀`.
- Cap the Weyl correction factor at 1.0 for ℓ estimates. When the mesh is underprovisioned (C < 1), the correction was calibrated far from the Weyl asymptotic regime and made ℓ estimates dramatically worse. With the cap, the raw Weyl estimate is used instead, which is conservative but much more reliable.

Addresses #436 — the ℓ estimates shown to @brendanjmeade were distorted by the uncapped correction. With this fix, the estimates are more useful for deciding how to adjust `matern_length_scale`.

Refs: #374

Made with [Cursor](https://cursor.com)