### PR TITLE
fix: pass backend to compute_log_likelihood to avoid hang

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -210,7 +210,7 @@ class Config(RelativePathSerializerMixin, BaseModel):
     mcmc_chains: int = 1
     """Number of parallel MCMC chains to run."""
 
-    mcmc_backend: Literal["numba", "jax"] = "numba"
+    mcmc_backend: Literal["numba", "jax"] = "jax"
     """Backend to use for MCMC computations."""
 
     mesh_default_eigenvector_algorithm: EigenvectorAlgorithm = "eigh"

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -1741,7 +1741,13 @@ def solve_mcmc(
     if "los_velocity" in pymc_model.named_vars:
         ll_vars.append("los_velocity")
     logger.info(f"Computing pointwise log-likelihoods for {ll_vars}")
-    pm.compute_log_likelihood(trace, model=pymc_model, var_names=ll_vars)
+    backend_mode = model.config.mcmc_backend.upper()
+    pm.compute_log_likelihood(
+        trace,
+        model=pymc_model,
+        var_names=ll_vars,
+        compile_kwargs={"mode": backend_mode},
+    )
 
     state_vector = _state_vector_from_draw(
         model, operators, trace.mean(["chain", "draw"])


### PR DESCRIPTION
## Summary

- Pass `compile_kwargs={"mode": backend_mode}` to `pm.compute_log_likelihood` so it uses the same NUMBA/JAX backend as nutpie for sampling. Without this, PyMC falls back to the default (slow) C backend, causing the post-sampling log-likelihood step to take hours and appear to hang for large models like WNA (~25k stations).
- Change the default `mcmc_backend` from `"numba"` to `"jax"`.

Fixes #440

Made with [Cursor](https://cursor.com)