### PR TITLE
feat: configurable sigmoid slope for two-sided coupling constraint

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -340,6 +340,25 @@ class Config(RelativePathSerializerMixin, BaseModel):
     in the per-mesh configuration.
     """
 
+    mcmc_default_mesh_sigmoid_slope: float = 4.0
+    """Default slope factor for the two-sided sigmoid constraint transform.
+
+    Controls how sharply the unconstrained latent field is squashed into the
+    bounded interval ``[lower, upper]`` (e.g. coupling in [0, 1]). The
+    transform is ``sigmoid(slope * (x - midpoint) / scale) * scale + lower``,
+    so the derivative at the midpoint equals ``slope / 4``.
+
+    - ``4.0`` (default) gives unit slope at the midpoint, preserving the
+      historical behavior — modest excursions saturate near the bounds,
+      tending to produce near-binary coupling fields.
+    - Smaller values (e.g. ``1.0``) widen the transition zone in latent
+      space, allowing more intermediate constrained values.
+    - Larger values produce sharper, more step-like transitions.
+
+    Propagated to each mesh's ``sigmoid_slope`` unless overridden in the
+    per-mesh configuration.
+    """
+
     mcmc_default_mesh_top_elastic_constraint_sigma: float = 0.5
     """Default sigma for the artificial observed 0s on elastic velocities at
     the top boundary, used in MCMC when ``top_slip_rate_constraint == 1``.
@@ -564,6 +583,7 @@ class Config(RelativePathSerializerMixin, BaseModel):
             # Other MCMC parameters
             "gp_parameterization": self.mcmc_default_mesh_gp_parameterization,
             "softplus_lengthscale": self.mcmc_default_mesh_softplus_lengthscale,
+            "sigmoid_slope": self.mcmc_default_mesh_sigmoid_slope,
             # Boundary constraint sigmas
             "top_elastic_constraint_sigma": self.mcmc_default_mesh_top_elastic_constraint_sigma,
             "bottom_elastic_constraint_sigma": self.mcmc_default_mesh_bottom_elastic_constraint_sigma,

--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -289,6 +289,20 @@ class MeshConfig(RelativePathSerializerMixin, BaseModel):
     UNITS: [mm/yr] for elastic constraints, [dimensionless] for coupling
     """
 
+    sigmoid_slope: float | None = None
+    """Slope factor for the two-sided sigmoid constraint transform.
+
+    When None, uses default from Config.mcmc_default_mesh_sigmoid_slope.
+    Controls how sharply the unconstrained latent field is squashed into the
+    bounded interval (e.g. coupling in [0, 1]). The derivative of the
+    constraining transform at the midpoint of the interval equals
+    ``sigmoid_slope / 4``. Smaller values widen the transition zone (more
+    intermediate values); larger values produce sharper, more step-like
+    transitions.
+
+    UNITS: [dimensionless]
+    """
+
     # When None, uses the default from the top-level Config
     # (propagated by Config.apply_mesh_defaults).
     gp_parameterization: Literal["centered", "non_centered"] | None = None

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -104,6 +104,7 @@ def _constrain_field(
     lower: float | None,
     upper: float | None,
     softplus_lengthscale: float | None = None,
+    sigmoid_slope: float = 4.0,
 ):
     """Optionally transform values to satisfy bounds, using sigmoid or softplus.
 
@@ -120,7 +121,8 @@ def _constrain_field(
     while large negative values satisfy output ≈ input.
 
     Two bounds: A sigmoid scaled to the range [lower, upper] is used.
-    The midpoint of the range maps to itself with unit slope (f'(midpoint) = 1).
+    The midpoint of the range maps to itself with slope ``sigmoid_slope / 4``
+    (so the default ``sigmoid_slope = 4.0`` gives unit slope at the midpoint).
 
     Parameters
     ----------
@@ -133,13 +135,22 @@ def _constrain_field(
     softplus_lengthscale : float | None
         Length scale for softplus operations when only one bound is present.
         Required when exactly one of lower/upper is set.
+    sigmoid_slope : float
+        Slope factor for the two-sided sigmoid transform. Larger values
+        produce sharper transitions; smaller values widen the transition
+        zone, allowing more intermediate constrained values. Defaults to
+        4.0, which gives unit slope at the midpoint (the historical
+        behavior). Only used when both bounds are set.
     """
     import pymc as pm
 
     if lower is not None and upper is not None:
         scale = upper - lower
         midpoint = (lower + upper) / 2
-        return pm.math.sigmoid(4 * (values - midpoint) / scale) * scale + lower  # type: ignore[attr-defined]
+        return (
+            pm.math.sigmoid(sigmoid_slope * (values - midpoint) / scale) * scale  # type: ignore[attr-defined]
+            + lower
+        )
 
     if lower is not None:
         if softplus_lengthscale is None:
@@ -197,6 +208,7 @@ def _unconstrain_field(
     lower: float | None,
     upper: float | None,
     softplus_lengthscale: float | None = None,
+    sigmoid_slope: float = 4.0,
 ) -> np.ndarray:
     """Inverse of _constrain_field: map constrained values to unconstrained space.
 
@@ -216,6 +228,10 @@ def _unconstrain_field(
     softplus_lengthscale : float | None
         Length scale for softplus operations when only one bound is present.
         Required when exactly one of lower/upper is set.
+    sigmoid_slope : float
+        Slope factor for the two-sided sigmoid transform. Must match the
+        value used in the corresponding ``_constrain_field`` call. Defaults
+        to 4.0. Only used when both bounds are set.
 
     Returns
     -------
@@ -227,10 +243,10 @@ def _unconstrain_field(
     if lower is not None and upper is not None:
         scale = upper - lower
         midpoint = (lower + upper) / 2
-        # y = sigmoid(4 * (x - midpoint) / scale) * scale + lower
-        # => x = midpoint + scale * logit((y - lower) / scale) / 4
+        # y = sigmoid(sigmoid_slope * (x - midpoint) / scale) * scale + lower
+        # => x = midpoint + scale * logit((y - lower) / scale) / sigmoid_slope
         normalized = (values - lower) / scale
-        return midpoint + scale * logit(normalized) / 4
+        return midpoint + scale * logit(normalized) / sigmoid_slope
 
     if lower is not None:
         if softplus_lengthscale is None:
@@ -264,6 +280,7 @@ def _get_unconstrained_mean(
     upper: float | None,
     softplus_lengthscale: float | None,
     field_name: str,
+    sigmoid_slope: float = 4.0,
 ) -> float:
     """Convert a prior mean to unconstrained space.
 
@@ -310,7 +327,7 @@ def _get_unconstrained_mean(
         )
 
     return _unconstrain_field(
-        np.array([mean]), lower, upper, softplus_lengthscale
+        np.array([mean]), lower, upper, softplus_lengthscale, sigmoid_slope
     ).item()
 
 
@@ -570,6 +587,10 @@ def _coupling_component(
     )
     n_eigs = variances.size
     softplus_lengthscale = model.meshes[mesh_idx].config.softplus_lengthscale
+    sigmoid_slope = model.meshes[mesh_idx].config.sigmoid_slope
+    assert sigmoid_slope is not None, (
+        "MeshConfig.sigmoid_slope must be set (propagated by Config.apply_mesh_defaults)"
+    )
 
     if model.meshes[mesh_idx].config.gp_parameterization == "non_centered":
         # Non-centered: sample white noise, then mollify via eigenvalue scaling
@@ -594,7 +615,7 @@ def _coupling_component(
     # Add mean offset in unconstrained space before constraining
     coupling_field = _operator_mult(eigenvectors, coefs) + mu_unconstrained
     coupling_field = _constrain_field(
-        coupling_field, lower, upper, softplus_lengthscale
+        coupling_field, lower, upper, softplus_lengthscale, sigmoid_slope
     )
     pm.Deterministic(f"coupling_{mesh_idx}_{kind_short}", coupling_field)
     elastic_tde = kinematic * coupling_field
@@ -681,6 +702,10 @@ def _elastic_component(
     )
     n_eigs = variances.size
     softplus_lengthscale = model.meshes[mesh_idx].config.softplus_lengthscale
+    sigmoid_slope = model.meshes[mesh_idx].config.sigmoid_slope
+    assert sigmoid_slope is not None, (
+        "MeshConfig.sigmoid_slope must be set (propagated by Config.apply_mesh_defaults)"
+    )
 
     if model.meshes[mesh_idx].config.gp_parameterization == "non_centered":
         # Non-centered: sample white noise, then mollify via eigenvalue scaling
@@ -706,6 +731,7 @@ def _elastic_component(
         lower,
         upper,
         softplus_lengthscale,
+        sigmoid_slope,
     )
     pm.Deterministic(f"elastic_{mesh_idx}_{kind_short}", elastic_tde)
 
@@ -823,6 +849,8 @@ def _mesh_component(
     assert config.coupling_mean is not None
     assert config.elastic_sigma is not None
     assert config.elastic_mean is not None
+    assert config.sigmoid_slope is not None
+    sigmoid_slope = config.sigmoid_slope
 
     for kind in kinds:
         kind_short = {"strike_slip": "ss", "dip_slip": "ds"}[kind]
@@ -847,6 +875,7 @@ def _mesh_component(
                 coupling_limit.upper,
                 config.softplus_lengthscale,
                 f"coupling_{kind_short} mesh {mesh_idx}",
+                sigmoid_slope=sigmoid_slope,
             )
             elastic_tde, station_vels, los_vels = _coupling_component(
                 model,
@@ -869,6 +898,7 @@ def _mesh_component(
                 rate_limit.upper,
                 config.softplus_lengthscale,
                 f"elastic_{kind_short} mesh {mesh_idx}",
+                sigmoid_slope=sigmoid_slope,
             )
             elastic_tde, station_vels, los_vels = _elastic_component(
                 model,

--- a/tests/test_solve_mcmc.py
+++ b/tests/test_solve_mcmc.py
@@ -128,6 +128,48 @@ class TestConstrainFieldProperties:
         assert_allclose(constrained, [large_negative], rtol=1e-3)
 
 
+class TestSigmoidSlope:
+    """Test that sigmoid_slope controls the two-sided sigmoid sharpness."""
+
+    @pytest.mark.parametrize("sigmoid_slope", [1.0, 2.0, 4.0, 8.0])
+    def test_slope_at_midpoint_equals_slope_over_four(self, sigmoid_slope):
+        """Derivative at the midpoint equals sigmoid_slope / 4 for two-bounded case."""
+        lower, upper = 0.0, 10.0
+        midpoint = (lower + upper) / 2
+        eps = 1e-6
+        values = np.array([midpoint - eps, midpoint + eps])
+        constrained = _eval_if_tensor(
+            _constrain_field(values, lower, upper, sigmoid_slope=sigmoid_slope)
+        )
+        slope = (constrained[1] - constrained[0]) / (2 * eps)
+        assert_allclose(slope, sigmoid_slope / 4, rtol=1e-4)
+
+    @pytest.mark.parametrize("sigmoid_slope", [0.5, 1.0, 4.0, 10.0])
+    def test_two_bounds_roundtrip_with_slope(self, sigmoid_slope):
+        """Roundtrip works for arbitrary sigmoid_slope."""
+        lower, upper = 0.0, 1.0
+        values = np.array([-3.0, -1.0, 0.0, 1.0, 3.0])
+        constrained = _eval_if_tensor(
+            _constrain_field(values, lower, upper, sigmoid_slope=sigmoid_slope)
+        )
+        assert np.all(constrained > lower)
+        assert np.all(constrained < upper)
+        unconstrained = _unconstrain_field(
+            constrained, lower, upper, sigmoid_slope=sigmoid_slope
+        )
+        assert_allclose(unconstrained, values, rtol=1e-6, atol=1e-12)
+
+    def test_default_slope_matches_unit_slope_behavior(self):
+        """Default sigmoid_slope=4.0 preserves the historical unit-slope behavior."""
+        lower, upper = 0.0, 1.0
+        values = np.array([-2.0, -0.5, 0.0, 0.5, 2.0])
+        explicit = _eval_if_tensor(
+            _constrain_field(values, lower, upper, sigmoid_slope=4.0)
+        )
+        default = _eval_if_tensor(_constrain_field(values, lower, upper))
+        assert_allclose(default, explicit)
+
+
 class TestUnconstrainFieldErrors:
     """Test error handling in _unconstrain_field."""
 


### PR DESCRIPTION
The two-sided sigmoid in `_constrain_field` previously hard-coded a slope factor of 4 (giving unit slope at the midpoint), which causes modest excursions of the latent GP to saturate near the bounds and tends to produce near-binary coupling fields. Expose this as `mcmc_default_mesh_sigmoid_slope` (default 4.0, preserves existing behavior) on `Config`, mirror as `MeshConfig.sigmoid_slope` for per-mesh overrides, and thread through `_constrain_field`, `_unconstrain_field`, and `_get_unconstrained_mean`. Smaller values widen the transition zone and allow more intermediate coupling values.