### PR TITLE
Add upper bound preventing ArviZ v1

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -16,6 +16,7 @@ CELERI_HATCH_VCS_RUNTIME_VERSION = "1"
 pixi-global-install-shim-hack = "python -m celeri.scripts.pixi_global_install_shim_hack"
 
 [dependencies]
+arviz = "<1.0.0"
 colorcet = ">=3.1.0"
 compilers = ">=1.9.0"
 cutde = ">=25.7.24"


### PR DESCRIPTION
There have been several breaking changes in the new v1 ArviZ interface, and probably celeri requires some minor modifications.

In order to do this in a controlled way, I recommend adding an upper-bound to prevent v1 installs until we can adequately test.

Unfortunately this will prevent PyMC v6, but I don't think there are any v6 features that would have a substantial effect on celeri, so not a big deal for now.