### PR TITLE
Minor changes to Matlab conversion scripts

### DIFF
--- a/convert/block2csv.m
+++ b/convert/block2csv.m
@@ -12,11 +12,11 @@ block.euler_lat = block.eulerLat;
 block.euler_lat_sig = block.eulerLatSig;
 block.rotation_rate = block.rotationRate;
 block.rotation_rate_sig = block.rotationRateSig;
-block.rotation_flag = block.rotationInfo;
-block.apriori_flag = block.aprioriTog;
+block.rotation_flag = block.aprioriTog;
+block.apriori_flag = zeros(numel(block.interior_lon), 1);
 block.strain_rate = zeros(numel(block.interior_lon), 1);
 block.strain_rate_sig = zeros(numel(block.interior_lon), 1);
-block.strain_rate_flag = zeros(numel(block.interior_lon), 1);
+block.strain_rate_flag = block.rotationInfo;
 
 % Delete old field names
 block = rmfield(block, "interiorLon");

--- a/convert/mat2msh.m
+++ b/convert/mat2msh.m
@@ -5,8 +5,8 @@ function mat2msh(matfile)
 p = ReadPatches(matfile);
 
 % Initialize msh file
-[~, fname] = fileparts(matfile);
-fid = fopen([fname '.msh'], 'w');
+[path, fname] = fileparts(matfile);
+fid = fopen([path filesep fname '.msh'], 'w');
 fprintf(fid, '$MeshFormat\n2 0 8\n$EndMeshFormat\n$Nodes\n');
 % Write nodes
 fprintf(fid, '%g\n', p.nc);
@@ -17,4 +17,4 @@ fprintf(fid, '%g\n', p.nEl);
 fprintf(fid, '%g %g %g %g %g %g %g %g %g\n', [1:p.nEl; repmat([2 3 0 1 0]', 1, p.nEl); p.v']);
 fprintf(fid, '$EndElements');
 fclose(fid);
-fprintf(1, 'Wrote %s\n', [fname '.msh'])
+fprintf(1, 'Wrote %s\n', [path filesep fname '.msh'])


### PR DESCRIPTION
`block2csv.m`: Changed so that strain and _a priori_ flags are correctly inserted into the `.csv` file
`mat2msh.m`: Writes to directory of the `.mat` file, rather than to `cwd`