### PR TITLE
Process horizontal meshes

### DIFF
--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -565,7 +565,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 1:
+    if len(zero_idx) > 0 & len(depth_count) > 1:
         if np.abs(depth_bin_max[zero_idx[0]] - depth_bin_min[zero_idx[-1] + 1]) > 10:
             tops[centroid_depths < depth_bins[zero_idx[0]]] = False
     # Assign in to meshes dict
@@ -593,7 +593,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 1:
+    if len(zero_idx) > 0 & len(depth_count) > 1:
         if abs(depth_bin_min[zero_idx[-1]] - depth_bin_max[zero_idx[0] - 1]) > 10:
             bots[centroid_depths > depth_bin_min[zero_idx[-1]]] = False
     # Assign in to meshes dict

--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -565,7 +565,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0:
+    if len(zero_idx) > 1:
         if np.abs(depth_bin_max[zero_idx[0]] - depth_bin_min[zero_idx[-1] + 1]) > 10:
             tops[centroid_depths < depth_bins[zero_idx[0]]] = False
     # Assign in to meshes dict
@@ -593,7 +593,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0:
+    if len(zero_idx) > 1:
         if abs(depth_bin_min[zero_idx[-1]] - depth_bin_max[zero_idx[0] - 1]) > 10:
             bots[centroid_depths > depth_bin_min[zero_idx[-1]]] = False
     # Assign in to meshes dict

--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -565,7 +565,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0 & len(depth_count) > 1:
+    if len(zero_idx) > 0:
         if np.abs(depth_bin_max[zero_idx[0]] - depth_bin_min[zero_idx[-1] + 1]) > 10:
             tops[centroid_depths < depth_bins[zero_idx[0]]] = False
     # Assign in to meshes dict
@@ -593,7 +593,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0 & len(depth_count) > 1:
+    if len(zero_idx) > 0:
         if abs(depth_bin_min[zero_idx[-1]] - depth_bin_max[zero_idx[0] - 1]) > 10:
             bots[centroid_depths > depth_bin_min[zero_idx[-1]]] = False
     # Assign in to meshes dict

--- a/celeri/mesh.py
+++ b/celeri/mesh.py
@@ -565,7 +565,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0:
+    if (len(zero_idx) > 0) & (len(depth_count) > 1):
         if np.abs(depth_bin_max[zero_idx[0]] - depth_bin_min[zero_idx[-1] + 1]) > 10:
             tops[centroid_depths < depth_bins[zero_idx[0]]] = False
     # Assign in to meshes dict
@@ -593,7 +593,7 @@ def _compute_mesh_edge_elements(mesh: dict):
     depth_bin_min = depth_bins[0:-1]
     depth_bin_max = depth_bins[1:]
     zero_idx = np.where(depth_count == 0)[0]
-    if len(zero_idx) > 0:
+    if (len(zero_idx) > 0) & (len(depth_count) > 1):
         if abs(depth_bin_min[zero_idx[-1]] - depth_bin_max[zero_idx[0] - 1]) > 10:
             bots[centroid_depths > depth_bin_min[zero_idx[-1]]] = False
     # Assign in to meshes dict

--- a/convert/block2csv.m
+++ b/convert/block2csv.m
@@ -12,11 +12,11 @@ block.euler_lat = block.eulerLat;
 block.euler_lat_sig = block.eulerLatSig;
 block.rotation_rate = block.rotationRate;
 block.rotation_rate_sig = block.rotationRateSig;
-block.rotation_flag = block.rotationInfo;
-block.apriori_flag = block.aprioriTog;
+block.rotation_flag = block.aprioriTog;
+block.apriori_flag = zeros(numel(block.interior_lon), 1);
 block.strain_rate = zeros(numel(block.interior_lon), 1);
 block.strain_rate_sig = zeros(numel(block.interior_lon), 1);
-block.strain_rate_flag = zeros(numel(block.interior_lon), 1);
+block.strain_rate_flag = block.rotationInfo;
 
 % Delete old field names
 block = rmfield(block, "interiorLon");

--- a/convert/mat2msh.m
+++ b/convert/mat2msh.m
@@ -5,8 +5,8 @@ function mat2msh(matfile)
 p = ReadPatches(matfile);
 
 % Initialize msh file
-[~, fname] = fileparts(matfile);
-fid = fopen([fname '.msh'], 'w');
+[path, fname] = fileparts(matfile);
+fid = fopen([path filesep fname '.msh'], 'w');
 fprintf(fid, '$MeshFormat\n2 0 8\n$EndMeshFormat\n$Nodes\n');
 % Write nodes
 fprintf(fid, '%g\n', p.nc);
@@ -17,4 +17,4 @@ fprintf(fid, '%g\n', p.nEl);
 fprintf(fid, '%g %g %g %g %g %g %g %g %g\n', [1:p.nEl; repmat([2 3 0 1 0]', 1, p.nEl); p.v']);
 fprintf(fid, '$EndElements');
 fclose(fid);
-fprintf(1, 'Wrote %s\n', [fname '.msh'])
+fprintf(1, 'Wrote %s\n', [path filesep fname '.msh'])


### PR DESCRIPTION
For truly horizontal meshes, which can be easier to use compared to slightly dipping meshes for BELs that share one side with the deep edge of a subduction zone, `mesh.py` would fail because of some of the depth checking that is done to assign edge-lining elements to top, bottom, and side. This minor change to `mesh.py` just prevents two (very similar) conditional statements from being entered when doing some refinement of adding elements to the `top` and `bottom` lists for horizontal meshes. Those conditional statements were based on histograms of depths along the top and bottom of a mesh, which is not meaningful for horizontal meshes. The change just says that a histogram 

The net result of this change is that all edge-lining elements of a horizontal mesh are assigned to be `side` elements, so technically they could still have edge slip rate constraints applied, with that categorization in mind. 

For the 3 Japan 187 Western US meshes, no differences in the edge element categorization resulted from this change, so I think it's pretty unobtrusive. 