### PR TITLE
Honor --mesh_parameters_file_name CLI override (issue #462)

### DIFF
--- a/celeri/cli.py
+++ b/celeri/cli.py
@@ -1,8 +1,9 @@
 import argparse
+from pathlib import Path
 
 from loguru import logger
 
-from celeri.config import Config
+from celeri.config import Config, load_mesh_params
 
 
 def str2bool(v):
@@ -327,3 +328,16 @@ def process_args(config: Config, args: argparse.Namespace):
                     logger.warning(f"ORIGINAL: config.{key}: {original_val}")
                     setattr(config, key, args_val)
                     logger.warning(f"REPLACED: config.{key}: {args_val}")
+
+    # The per-mesh parameter list (config.mesh_params) is loaded eagerly in
+    # get_config from the original config file, so overriding only the path
+    # above would be silently ignored by build_model (issue #462). Re-load the
+    # list whenever --mesh_parameters_file_name is supplied. CLI paths are
+    # resolved relative to the cwd, matching how other --*_file_name overrides
+    # are consumed (e.g. station/segment/block files are read by path at build
+    # time). propagate_mesh_defaults still runs later in read_data, so inherited
+    # defaults are filled in from the (already overridden) top-level config.
+    mesh_params_path = getattr(args, "mesh_parameters_file_name", None)
+    if mesh_params_path is not None:
+        config.mesh_params = load_mesh_params(Path(mesh_params_path), Path.cwd())
+        logger.success(f"Read: {mesh_params_path}")

--- a/celeri/config.py
+++ b/celeri/config.py
@@ -636,6 +636,27 @@ def _get_output_path(base: Path) -> Path:
         )
 
 
+def load_mesh_params(
+    mesh_parameters_file_name: Path | str | None,
+    base_dir: Path,
+) -> list[MeshConfig]:
+    """Load the per-mesh parameter list from a mesh-parameters JSON file.
+
+    Relative paths are resolved against ``base_dir`` (the config-file directory
+    when called from ``get_config``, or the current working directory when
+    re-loading after a command-line override in ``process_args``). Returns an
+    empty list when ``mesh_parameters_file_name`` is None.
+
+    Note: the returned configs still have ``None`` for every field that inherits
+    from the top-level Config; those are filled in later by
+    ``Config.propagate_mesh_defaults`` (deferred until ``read_data`` so that CLI
+    overrides take effect first).
+    """
+    if mesh_parameters_file_name is None:
+        return []
+    return MeshConfig.from_file(base_dir / mesh_parameters_file_name)
+
+
 def get_config(file_name: Path | str) -> Config:
     """Read config from a JSON file and return a Config instance.
 
@@ -656,10 +677,7 @@ def get_config(file_name: Path | str) -> Config:
     config_data["output_path"] = _get_output_path(base_runs_folder)
 
     mesh_parameters_file_name = config_data.get("mesh_parameters_file_name", None)
-    if mesh_parameters_file_name is None:
-        mesh_params = []
-    else:
-        mesh_params = MeshConfig.from_file(file_path.parent / mesh_parameters_file_name)
+    mesh_params = load_mesh_params(mesh_parameters_file_name, file_path.parent)
 
     # Top-level defaults are propagated to mesh configs by Config.apply_mesh_defaults
     config_data["mesh_params"] = mesh_params

--- a/tests/test_process_args.py
+++ b/tests/test_process_args.py
@@ -1,0 +1,65 @@
+"""Tests for command-line argument processing (celeri.cli.process_args)."""
+
+import argparse
+import json
+from pathlib import Path
+
+from celeri import get_config, process_args
+
+CONFIG = Path("tests/configs/test_japan_config.json")
+ORIGINAL_MESH_PARAMS = Path("tests/data/mesh/test_japan_mesh_parameters.json")
+
+
+def _write_alt_mesh_params(dest: Path, n_modes: int) -> None:
+    """Write a copy of the test mesh-parameters file with a distinctive value."""
+    params = json.loads(ORIGINAL_MESH_PARAMS.read_text())
+    for entry in params:
+        entry["n_modes_strike_slip"] = n_modes
+    dest.write_text(json.dumps(params, indent=4))
+
+
+def test_mesh_parameters_file_name_override_reloads_mesh_params(tmp_path):
+    """--mesh_parameters_file_name override must re-load config.mesh_params.
+
+    Regression test for issue #462: process_args updated the path field but the
+    eagerly-loaded mesh_params list (consumed by build_model) still reflected
+    the original file.
+    """
+    # The original file uses n_modes_strike_slip == 50; make the alternate use 7.
+    original_modes = json.loads(ORIGINAL_MESH_PARAMS.read_text())[0][
+        "n_modes_strike_slip"
+    ]
+    assert original_modes != 7
+    alt = tmp_path / "alt_mesh_parameters.json"
+    _write_alt_mesh_params(alt, n_modes=7)
+
+    config = get_config(CONFIG)
+    # Sanity: before override, mesh_params come from the original file.
+    assert config.mesh_params[0].n_modes_strike_slip == original_modes
+
+    args = argparse.Namespace(
+        config_file_name=str(CONFIG),
+        mesh_parameters_file_name=str(alt),
+    )
+    process_args(config, args)
+
+    # Both the path field AND the actual loaded parameters must reflect the alt file.
+    assert config.mesh_parameters_file_name == str(alt)
+    assert config.mesh_params, "mesh_params should be non-empty"
+    for mesh_param in config.mesh_params:
+        assert mesh_param.n_modes_strike_slip == 7
+        assert mesh_param.file_name == alt.resolve()
+
+
+def test_no_mesh_override_leaves_mesh_params_untouched():
+    """Without the override, mesh_params stay as loaded from the config file."""
+    config = get_config(CONFIG)
+    expected = [m.n_modes_strike_slip for m in config.mesh_params]
+
+    args = argparse.Namespace(
+        config_file_name=str(CONFIG),
+        mesh_parameters_file_name=None,
+    )
+    process_args(config, args)
+
+    assert [m.n_modes_strike_slip for m in config.mesh_params] == expected


### PR DESCRIPTION
## Summary

Fixes #462. The `--mesh_parameters_file_name` command-line override to `celeri-solve` was logged as applied but silently ignored.

**Root cause:** `Config` holds both `mesh_parameters_file_name` (the path) and `mesh_params` (the eagerly-loaded per-mesh parameter list). `get_config` loads `mesh_params` from the original config file, and `build_model` consumes `mesh_params` — but `process_args` only updated the *path* field. So the override produced the `ORIGINAL`/`REPLACED` log lines without changing the parameters actually used. (Station/segment/block overrides work because those files are read by path at build time, not pre-loaded.)

## Changes

- **`celeri/config.py`** — Extract the path→`mesh_params` load into a shared `load_mesh_params(path, base_dir)` helper; `get_config` now calls it (pure refactor, behavior unchanged).
- **`celeri/cli.py`** — `process_args` re-loads `config.mesh_params` via the helper whenever `--mesh_parameters_file_name` is supplied. CLI paths resolve relative to the cwd, matching the other `--*_file_name` overrides, and a `SUCCESS Read:` line is logged. `propagate_mesh_defaults` still runs later in `read_data`, so inherited mesh defaults are filled from the (already-overridden) top-level config.
- **`tests/test_process_args.py`** — New regression tests for the override and the no-override case (uses `tmp_path`, no committed fixture).

## Why this approach

A fuller redesign making `mesh_params` lazily derived from the path would break the load→mutate→build pattern that `test_optimize.py` and `scripts/segmesh.py` depend on — segmesh points the path at a file it *writes from* `mesh_params`, which makes a path→list derivation circular. This localized fix removes the path/list drift without disturbing those flows.

## Note

A CLI-supplied **relative** mesh-params path now resolves relative to the **cwd** (consistent with the other file-name overrides), which differs from the config-dir-relative resolution used for the path inside the config JSON. Absolute paths are unambiguous either way.

## Testing

- New regression tests pass; reproduction confirms `mesh_params` now reflects the alternate file.
- `tests/test_serialize.py` (exercises the refactored `get_config`/`MeshConfig.from_file` round-trip) passes — 13 passed total.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)