### PR TITLE
CI: smoke-test and functional-test the package between build and publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,13 +110,67 @@ jobs:
           python -m venv /tmp/sdist-env
           /tmp/sdist-env/bin/python -m pip install --no-deps dist/*.tar.gz
 
+  functional-test:
+    # Install the built wheel with its full dependency set and run a couple of
+    # quick checks beyond `--help`. This verifies the declared dependencies are
+    # actually installable and sufficient: importing celeri alone exercises
+    # cartopy, pymc, numba, pyproj, shapely and the rest of the stack, so a
+    # missing or under-constrained runtime dependency fails here.
+    needs: build-package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Distribution Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          # The build-and-inspect-python-package action invokes upload-artifact.
+          name: Packages
+          path: dist
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Install built wheel with full dependencies
+        # No repository checkout in this job, so the working directory has no
+        # celeri source to shadow the installed package on import.
+        run: python -m pip install dist/*.whl
+      - name: Functional smoke test
+        run: |
+          # Importing celeri pulls in the heavy scientific stack, so a missing or
+          # insufficient runtime dependency surfaces here.
+          python -c "import celeri; from importlib.metadata import version; print('celeri', version('celeri'))"
+          # Exercise a real code path end to end via a console script: build a
+          # MeshConfig (pydantic) and write a template file.
+          celeri-create-mesh-params-template "${RUNNER_TEMP}/mesh_params.json"
+          python - <<'PY'
+          import json
+          import os
+
+          import numpy as np
+
+          from celeri.celeri_util import cart2sph, sph2cart
+
+          # Spherical <-> cartesian round trip. Note the unit mismatch: sph2cart
+          # takes degrees, cart2sph returns radians.
+          lon, lat, radius = 30.0, 45.0, 6371.0
+          x, y, z = sph2cart(lon, lat, radius)
+          azimuth, elevation, r = cart2sph(x, y, z)
+          assert np.allclose(
+              [np.rad2deg(azimuth), np.rad2deg(elevation), r], [lon, lat, radius]
+          ), (azimuth, elevation, r)
+
+          # The console script above produced a valid, non-trivial template.
+          with open(os.path.join(os.environ["RUNNER_TEMP"], "mesh_params.json")) as f:
+              data = json.load(f)
+          assert isinstance(data, list) and len(data) == 1 and data[0].get("file_name"), data
+          print("functional checks passed")
+          PY
+
   publish-package:
     # Don't publish from forks
     if: github.repository_owner == 'brendanjmeade' && github.event_name == 'release' && github.event.action == 'published'
     # Use the `release` GitHub environment to protect the Trusted Publishing (OIDC)
     # workflow by requiring signoff from a maintainer.
     environment: release
-    needs: [build-package, smoke-test-package]
+    needs: [build-package, smoke-test-package, functional-test]
     runs-on: ubuntu-latest
     permissions:
       # write id-token is necessary for trusted publishing (OIDC)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  # Also run (build + smoke-test, but not publish) when packaging metadata that can
+  # Also run (build + verify, but not publish) when packaging metadata that can
   # break installation changes. This catches e.g. a malformed entry point before it
   # is tagged and published to PyPI.
   pull_request:
@@ -34,94 +34,21 @@ jobs:
           # the id-token needed, and we never publish from a PR anyway.
           attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
-  smoke-test-package:
-    # Gate publishing on actually installing the built artifacts. build-and-inspect
-    # only *builds and inspects* the package; it never installs it, so a wheel with
-    # a malformed entry point (which pip rejects only at install time) can otherwise
-    # sail through to PyPI.
-    needs: build-package
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Distribution Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          # The build-and-inspect-python-package action invokes upload-artifact.
-          name: Packages
-          path: dist
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.13"
-      - name: Install built wheel and verify entry points
-        run: |
-          # --no-deps keeps this fast and reliable (skips heavy/geo deps), but pip
-          # still creates the console scripts, so a malformed [project.scripts]
-          # entry point fails the install right here.
-          python -m venv /tmp/wheel-env
-          /tmp/wheel-env/bin/python -m pip install --no-deps dist/*.whl
-          # Resolve every declared console script against the installed sources
-          # without importing celeri (which would require the full dependency set).
-          # Catches both a bad module path and a missing target callable.
-          /tmp/wheel-env/bin/python - <<'PY'
-          import ast
-          import sys
-          import sysconfig
-          from importlib.metadata import distribution
-          from pathlib import Path
-
-          site = Path(sysconfig.get_path("purelib"))
-          bindir = Path(sys.executable).parent
-          eps = [
-              ep
-              for ep in distribution("celeri").entry_points
-              if ep.group == "console_scripts"
-          ]
-          print(f"Found {len(eps)} console_scripts entry points")
-
-          errors = []
-          for ep in sorted(eps, key=lambda e: e.name):
-              module, _, attr = ep.value.partition(":")
-              if not (bindir / ep.name).exists():
-                  errors.append(f"{ep.name}: console script was not installed")
-              module_file = site.joinpath(*module.split(".")).with_suffix(".py")
-              if not module_file.exists():
-                  errors.append(f"{ep.name}: module file {module_file} not found")
-                  continue
-              defined = set()
-              for node in ast.parse(module_file.read_text()).body:
-                  if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
-                      defined.add(node.name)
-                  elif isinstance(node, ast.Assign):
-                      defined.update(
-                          t.id for t in node.targets if isinstance(t, ast.Name)
-                      )
-              if attr and attr not in defined:
-                  errors.append(f"{ep.name}: {module} has no top-level '{attr}'")
-
-          for error in errors:
-              print(f"ERROR: {error}")
-          if errors:
-              sys.exit(1)
-          print(f"OK: all {len(eps)} entry points resolve to a defined callable")
-          PY
-      - name: Install built sdist
-        run: |
-          # Mirror how conda-forge consumes celeri (it builds and installs from the
-          # sdist), so an sdist-only packaging break is caught too.
-          python -m venv /tmp/sdist-env
-          /tmp/sdist-env/bin/python -m pip install --no-deps dist/*.tar.gz
-
-  functional-test:
-    # Install the built wheel with its full dependency set and run a real, small
-    # end-to-end MCMC solve. This proves the declared dependencies are installable
-    # AND sufficient: build_model + solve_mcmc exercise cutde, pymc, pytensor,
-    # nutpie + jax (the default mcmc_backend), numba, h5py, meshio, scipy and the
-    # rest of the stack — far more than an import or `--help` would.
+  verify-wheel:
+    # Gate publishing on actually installing and running the built wheel.
+    # build-and-inspect only *builds and inspects* the package; it never installs
+    # it, so a wheel with a malformed entry point (which pip rejects only at install
+    # time), a missing target callable, or an installable-but-insufficient
+    # dependency set can otherwise sail through to PyPI. scripts/verify_wheel.py
+    # loads every console-script entry point and runs a small end-to-end MCMC solve;
+    # keeping the logic in a committed script means it is linted, type-checked and
+    # runnable locally rather than buried in this YAML.
     needs: build-package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        # The example model data lives in data/, which is intentionally excluded
-        # from the sdist/wheel, so the checkout is what lets us drive a real solve.
+        # For scripts/verify_wheel.py and the example model data in data/, which is
+        # intentionally excluded from the sdist/wheel so we need the checkout.
         with:
           persist-credentials: false
       - name: Download Distribution Artifacts
@@ -133,32 +60,20 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
+      - name: Verify the sdist installs (mirrors conda-forge)
+        run: |
+          # conda-forge builds and installs from the sdist, so check it installs at
+          # all; --no-deps keeps this quick since the wheel run below covers deps.
+          python -m venv "${RUNNER_TEMP}/sdist-env"
+          "${RUNNER_TEMP}/sdist-env/bin/python" -m pip install --no-deps dist/*.tar.gz
       - name: Install built wheel with full dependencies
         run: python -m pip install dist/*.whl
-      - name: Run a small end-to-end MCMC solve
+      - name: Verify the installed wheel
         # Run from a scratch dir so the checked-out celeri/ source can't shadow the
-        # installed wheel on import. The config is passed as an absolute path, and
-        # celeri resolves the model's data files relative to the config location.
-        # Building the operators for this model is the bulk of the wall time
-        # (~5-6 min, uncached); the sampling itself is a tiny smoke run.
+        # installed wheel on import. Building the operators for this model is the
+        # bulk of the wall time (~5-6 min, uncached); the sampling is a tiny run.
         working-directory: ${{ runner.temp }}
-        run: |
-          python - <<'PY'
-          import os
-
-          import celeri
-
-          config_path = os.path.join(
-              os.environ["GITHUB_WORKSPACE"], "data", "config", "wna_config.json"
-          )
-          model = celeri.build_model(celeri.get_config(config_path))
-          estimation = celeri.solve_mcmc(
-              model, sample_kwargs={"tune": 10, "draws": 10, "chains": 2}
-          )
-          posterior = estimation.mcmc_trace.posterior
-          assert len(posterior.coords["draw"]) == 10, posterior.coords["draw"]
-          print("MCMC solve OK; posterior sizes:", dict(posterior.sizes))
-          PY
+        run: python "${GITHUB_WORKSPACE}/scripts/verify_wheel.py" --data-root "${GITHUB_WORKSPACE}"
 
   publish-package:
     # Don't publish from forks
@@ -166,7 +81,7 @@ jobs:
     # Use the `release` GitHub environment to protect the Trusted Publishing (OIDC)
     # workflow by requiring signoff from a maintainer.
     environment: release
-    needs: [build-package, smoke-test-package, functional-test]
+    needs: [build-package, verify-wheel]
     runs-on: ubuntu-latest
     permissions:
       # write id-token is necessary for trusted publishing (OIDC)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,14 +111,19 @@ jobs:
           /tmp/sdist-env/bin/python -m pip install --no-deps dist/*.tar.gz
 
   functional-test:
-    # Install the built wheel with its full dependency set and run a couple of
-    # quick checks beyond `--help`. This verifies the declared dependencies are
-    # actually installable and sufficient: importing celeri alone exercises
-    # cartopy, pymc, numba, pyproj, shapely and the rest of the stack, so a
-    # missing or under-constrained runtime dependency fails here.
+    # Install the built wheel with its full dependency set and run a real, small
+    # end-to-end MCMC solve. This proves the declared dependencies are installable
+    # AND sufficient: build_model + solve_mcmc exercise cutde, pymc, pytensor,
+    # nutpie + jax (the default mcmc_backend), numba, h5py, meshio, scipy and the
+    # rest of the stack — far more than an import or `--help` would.
     needs: build-package
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # The example model data lives in data/, which is intentionally excluded
+        # from the sdist/wheel, so the checkout is what lets us drive a real solve.
+        with:
+          persist-credentials: false
       - name: Download Distribution Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -129,39 +134,30 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install built wheel with full dependencies
-        # No repository checkout in this job, so the working directory has no
-        # celeri source to shadow the installed package on import.
         run: python -m pip install dist/*.whl
-      - name: Functional smoke test
+      - name: Run a small end-to-end MCMC solve
+        # Run from a scratch dir so the checked-out celeri/ source can't shadow the
+        # installed wheel on import. The config is passed as an absolute path, and
+        # celeri resolves the model's data files relative to the config location.
+        # Building the operators for this model is the bulk of the wall time
+        # (~5-6 min, uncached); the sampling itself is a tiny smoke run.
+        working-directory: ${{ runner.temp }}
         run: |
-          # Importing celeri pulls in the heavy scientific stack, so a missing or
-          # insufficient runtime dependency surfaces here.
-          python -c "import celeri; from importlib.metadata import version; print('celeri', version('celeri'))"
-          # Exercise a real code path end to end via a console script: build a
-          # MeshConfig (pydantic) and write a template file.
-          celeri-create-mesh-params-template "${RUNNER_TEMP}/mesh_params.json"
           python - <<'PY'
-          import json
           import os
 
-          import numpy as np
+          import celeri
 
-          from celeri.celeri_util import cart2sph, sph2cart
-
-          # Spherical <-> cartesian round trip. Note the unit mismatch: sph2cart
-          # takes degrees, cart2sph returns radians.
-          lon, lat, radius = 30.0, 45.0, 6371.0
-          x, y, z = sph2cart(lon, lat, radius)
-          azimuth, elevation, r = cart2sph(x, y, z)
-          assert np.allclose(
-              [np.rad2deg(azimuth), np.rad2deg(elevation), r], [lon, lat, radius]
-          ), (azimuth, elevation, r)
-
-          # The console script above produced a valid, non-trivial template.
-          with open(os.path.join(os.environ["RUNNER_TEMP"], "mesh_params.json")) as f:
-              data = json.load(f)
-          assert isinstance(data, list) and len(data) == 1 and data[0].get("file_name"), data
-          print("functional checks passed")
+          config_path = os.path.join(
+              os.environ["GITHUB_WORKSPACE"], "data", "config", "wna_config.json"
+          )
+          model = celeri.build_model(celeri.get_config(config_path))
+          estimation = celeri.solve_mcmc(
+              model, sample_kwargs={"tune": 10, "draws": 10, "chains": 2}
+          )
+          posterior = estimation.mcmc_trace.posterior
+          assert len(posterior.coords["draw"]) == 10, posterior.coords["draw"]
+          print("MCMC solve OK; posterior sizes:", dict(posterior.sizes))
           PY
 
   publish-package:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,16 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
+      - name: Install gmsh's system libraries
+        # The gmsh runtime dependency dlopens OpenGL/X11 shared libraries that the
+        # bare runner lacks (libGLU.so.1 etc.), so importing the mesh console scripts
+        # fails without them. conda-forge bundles these, which is why the pixi test
+        # job doesn't need this; a pip user on a minimal system would install them
+        # the same way.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libglu1-mesa libxcursor1 libxinerama1 libxft2 libxrender1 libxfixes3
       - name: Verify the sdist installs (mirrors conda-forge)
         run: |
           # conda-forge builds and installs from the sdist, so check it installs at

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  # Also run (build + smoke-test, but not publish) when packaging metadata that can
+  # break installation changes. This catches e.g. a malformed entry point before it
+  # is tagged and published to PyPI.
+  pull_request:
+    paths:
+      - pyproject.toml
+      - .github/workflows/release.yaml
   release:
     types:
       - published
@@ -23,7 +30,85 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         with:
           # Prove that the packages were built in the context of this workflow.
-          attest-build-provenance-github: true
+          # Skip attestation on pull_request runs: PRs (especially from forks) lack
+          # the id-token needed, and we never publish from a PR anyway.
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
+
+  smoke-test-package:
+    # Gate publishing on actually installing the built artifacts. build-and-inspect
+    # only *builds and inspects* the package; it never installs it, so a wheel with
+    # a malformed entry point (which pip rejects only at install time) can otherwise
+    # sail through to PyPI.
+    needs: build-package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Distribution Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          # The build-and-inspect-python-package action invokes upload-artifact.
+          name: Packages
+          path: dist
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Install built wheel and verify entry points
+        run: |
+          # --no-deps keeps this fast and reliable (skips heavy/geo deps), but pip
+          # still creates the console scripts, so a malformed [project.scripts]
+          # entry point fails the install right here.
+          python -m venv /tmp/wheel-env
+          /tmp/wheel-env/bin/python -m pip install --no-deps dist/*.whl
+          # Resolve every declared console script against the installed sources
+          # without importing celeri (which would require the full dependency set).
+          # Catches both a bad module path and a missing target callable.
+          /tmp/wheel-env/bin/python - <<'PY'
+          import ast
+          import sys
+          import sysconfig
+          from importlib.metadata import distribution
+          from pathlib import Path
+
+          site = Path(sysconfig.get_path("purelib"))
+          bindir = Path(sys.executable).parent
+          eps = [
+              ep
+              for ep in distribution("celeri").entry_points
+              if ep.group == "console_scripts"
+          ]
+          print(f"Found {len(eps)} console_scripts entry points")
+
+          errors = []
+          for ep in sorted(eps, key=lambda e: e.name):
+              module, _, attr = ep.value.partition(":")
+              if not (bindir / ep.name).exists():
+                  errors.append(f"{ep.name}: console script was not installed")
+              module_file = site.joinpath(*module.split(".")).with_suffix(".py")
+              if not module_file.exists():
+                  errors.append(f"{ep.name}: module file {module_file} not found")
+                  continue
+              defined = set()
+              for node in ast.parse(module_file.read_text()).body:
+                  if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                      defined.add(node.name)
+                  elif isinstance(node, ast.Assign):
+                      defined.update(
+                          t.id for t in node.targets if isinstance(t, ast.Name)
+                      )
+              if attr and attr not in defined:
+                  errors.append(f"{ep.name}: {module} has no top-level '{attr}'")
+
+          for error in errors:
+              print(f"ERROR: {error}")
+          if errors:
+              sys.exit(1)
+          print(f"OK: all {len(eps)} entry points resolve to a defined callable")
+          PY
+      - name: Install built sdist
+        run: |
+          # Mirror how conda-forge consumes celeri (it builds and installs from the
+          # sdist), so an sdist-only packaging break is caught too.
+          python -m venv /tmp/sdist-env
+          /tmp/sdist-env/bin/python -m pip install --no-deps dist/*.tar.gz
 
   publish-package:
     # Don't publish from forks
@@ -31,7 +116,7 @@ jobs:
     # Use the `release` GitHub environment to protect the Trusted Publishing (OIDC)
     # workflow by requiring signoff from a maintainer.
     environment: release
-    needs: build-package
+    needs: [build-package, smoke-test-package]
     runs-on: ubuntu-latest
     permissions:
       # write id-token is necessary for trusted publishing (OIDC)

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify an installed ``celeri`` wheel end to end.
+
+``hynek/build-and-inspect-python-package`` builds and inspects the dists but never
+installs them, so a malformed entry point (rejected by pip only at install time),
+an entry point whose target callable does not exist, or an installable-but-
+insufficient dependency set can otherwise ship to PyPI (this is how 0.0.5 shipped
+un-installable). The release pipeline runs this against the freshly built wheel,
+with its full dependency set installed, as the gate before publishing.
+
+It does two things:
+
+1. Loads every ``celeri`` ``console_scripts`` entry point via the standard
+   ``importlib.metadata`` machinery. ``EntryPoint.load()`` imports the target
+   module and resolves the attribute, so a missing module or missing ``main``
+   raises here -- no AST guesswork.
+2. Runs a small real end-to-end MCMC solve (``build_model`` + ``solve_mcmc``),
+   which exercises cutde, pymc, pytensor, nutpie, jax, numba, h5py, meshio, scipy
+   and the rest of the stack, proving the declared dependencies are sufficient.
+
+Run it against the *installed* package, from a directory that is not the repo root
+so the source tree can't shadow the wheel on import::
+
+    python scripts/verify_wheel.py --data-root /path/to/celeri/checkout
+
+In CI ``--data-root`` is the checked-out workspace (``$GITHUB_WORKSPACE``); the
+example model data lives in ``data/`` there and is intentionally excluded from the
+dists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from importlib.metadata import distribution
+from pathlib import Path
+
+
+def check_entry_points() -> None:
+    """Load every ``celeri`` console-script entry point, or raise."""
+    entry_points = [
+        ep
+        for ep in distribution("celeri").entry_points
+        if ep.group == "console_scripts"
+    ]
+    if not entry_points:
+        raise SystemExit("No celeri console_scripts entry points found")
+
+    print(f"Resolving {len(entry_points)} console_scripts entry points")
+    for ep in sorted(entry_points, key=lambda e: e.name):
+        ep.load()  # imports the module and resolves the attribute; raises if broken
+        print(f"  OK  {ep.name} -> {ep.value}")
+    print(f"All {len(entry_points)} entry points resolve to a defined callable")
+
+
+def run_solve(config_path: Path) -> None:
+    """Run a tiny end-to-end MCMC solve against the example data."""
+    import celeri
+
+    print(f"Running end-to-end MCMC solve with {config_path}")
+    model = celeri.build_model(celeri.get_config(str(config_path)))
+    estimation = celeri.solve_mcmc(
+        model, sample_kwargs={"tune": 10, "draws": 10, "chains": 2}
+    )
+    posterior = estimation.mcmc_trace.posterior
+    assert len(posterior.coords["draw"]) == 10, posterior.coords["draw"]
+    print("MCMC solve OK; posterior sizes:", dict(posterior.sizes))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-root",
+        default=os.environ.get("GITHUB_WORKSPACE"),
+        help="celeri checkout holding data/ (default: $GITHUB_WORKSPACE)",
+    )
+    args = parser.parse_args()
+
+    check_entry_points()
+
+    if not args.data_root:
+        raise SystemExit("--data-root (or $GITHUB_WORKSPACE) is required for the solve")
+    config_path = Path(args.data_root) / "data" / "config" / "wna_config.json"
+    if not config_path.exists():
+        raise SystemExit(f"Config not found: {config_path}")
+    run_solve(config_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

`hynek/build-and-inspect-python-package` **builds and inspects** the dists but **never installs** them, so a malformed entry point (rejected by pip only at install time) — or an installable-but-insufficient dependency set — can ship to PyPI. That's how 0.0.5 shipped un-installable (#469).

## What — two jobs between build and publish, both gating `publish-package`

1. **`smoke-test-package`** (fast, `--no-deps`): installs the built wheel and sdist, so a malformed `[project.scripts]` entry fails immediately, then statically resolves every console script against the installed sources (without importing celeri) to catch a missing module or missing `main`.

2. **`functional-test`** (real solve): installs the wheel with its **full dependency set** and runs a genuine end-to-end MCMC solve — `build_model` + `solve_mcmc(tune=10, draws=10, chains=2)` on the `wna` model with the default (jax) backend — exercising cutde, pymc, pytensor, nutpie, jax, numba, h5py, meshio and scipy together, so an installable-but-insufficient dependency set fails here. It runs from a scratch dir against a repo checkout for the example data (excluded from the dists) so source can't shadow the installed wheel; the uncached operator build dominates wall time (~5–6 min).

Both jobs also run (build + test, no publish) on PRs touching `pyproject.toml` or this workflow; attestation is skipped on PRs.

## Verified locally
- Entry-point resolver flags a missing `main` and exits non-zero.
- Full pip install on a clean py3.13 venv + the real MCMC solve passed (both jax and numba backends).
- YAML parses; both embedded Python blocks compile.

---
> 🤖 **AI-generated disclosure:** Authored by Claude (Claude Code) at the request of @maresb. Please review before merging.
