### PR TITLE
Declare jax, rich, arviz and pytensor as `pyproject.toml` dependencies

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -27117,6 +27117,7 @@ packages:
 - pypi: .
   name: celeri
   requires_dist:
+  - arviz
   - cartopy
   - colorcet
   - cutde>=25.7.24
@@ -27126,6 +27127,7 @@ packages:
   - h5py
   - ipykernel
   - ipython
+  - jax ; (platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'
   - loguru
   - matplotlib
   - meshio
@@ -27138,7 +27140,9 @@ packages:
   - pydantic
   - pymc
   - pyproj
+  - pytensor
   - pytest
+  - rich
   - scikit-learn
   - scipy
   - shapely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
+    "arviz",
     "cartopy",
     "colorcet",
     "cutde>=25.7.24",
@@ -21,6 +22,7 @@ dependencies = [
     "h5py",
     "ipykernel",
     "ipython",
+    "jax; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')",
     "loguru",
     "matplotlib",
     "meshio",
@@ -33,7 +35,9 @@ dependencies = [
     "pydantic",
     "pymc",
     "pyproj",
+    "pytensor",
     "pytest",
+    "rich",
     "scikit-learn",
     "scipy",
     "shapely",


### PR DESCRIPTION
Result of a completeness audit of `pyproject.toml`, which defines the PyPI package.

1. Minor: add `rich`, `arviz`, and `pytensor`.

These are undeclared direct dependencies currently get pulled in by other dependencies, but if this were to change it would lead to breakage. So this is a robustness fix.

Medium: add `jax`

Before this PR, `pip install celeri` didn't work out-of-the-box since `pyproject.toml` is missing `jax`, which is our default backend.

---

AI-generated description:

## Why

These are needed at runtime but were only present **transitively** (via `pymc`/`nutpie`), so a plain `pip install celeri` wasn't guaranteed sufficient. `pixi.toml` already lists them on the conda side, so the gap only bit pip users.

| dep | why | form |
|---|---|---|
| **jax** | default `mcmc_backend="jax"` → `nutpie.compile_pymc_model(..., backend="jax")` imports jax at solve time | **platform marker** (below) |
| **rich** | imported directly in `celeri_util.py`, `operators.py`, `spatial.py` | plain |
| **arviz** | imported directly in `filter_mcmc_chains_by_waic.py`, `solve.py` | plain |
| **pytensor** | imported directly in `solve_mcmc.py` | plain |

### jax is platform-scoped to match pixi.toml

`pixi.toml` provides jax only under `[target.linux-64]` and `[target.osx-arm64]` — not Windows, not Intel macOS (no jaxlib wheel there). So jax is declared with a marker that matches exactly:

```
jax; platform_system == 'Linux' or (platform_system == 'Darwin' and platform_machine == 'arm64')
```

Consequence: on **Windows / Intel macOS**, celeri installs without jax and the default jax backend is unavailable — use `mcmc_backend="numba"` there (numba is already a core dep). This matches the platforms the project supports today.

## pixi.lock (second commit, isolated)

Regenerated with `pixi lock`. The **only** change is celeri's `requires_dist` gaining the four names (jax with the marker, normalized by uv) — **4 insertions, 0 deletions**, no package versions/sources/per-environment sets shifted. Audited to confirm jax is **not** added to win-64 or osx-64.

## Verification

pip-installed the built wheel (with these deps) into a clean py3.13 venv — all resolved to binary wheels — then ran a **real end-to-end MCMC solve** (`build_model` + `solve_mcmc`) on the `wna` model with **both** the jax (default) and numba backends: ✅.

---
> 🤖 **AI-generated disclosure:** Authored by Claude (Claude Code) at the request of @maresb. Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)