### PR TITLE
Cap arviz<1.0.0 so wheel installs match the tested major

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -27113,7 +27113,7 @@ packages:
 - pypi: .
   name: celeri
   requires_dist:
-  - arviz
+  - arviz<1.0.0
   - cartopy
   - colorcet
   - cutde>=25.7.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "arviz",
+    # celeri is not yet compatible with the ArviZ 1.x refactor; match the
+    # ceiling already set for the conda env in pixi.toml so wheel installs
+    # (pip) resolve the same supported major as the tested environment.
+    "arviz<1.0.0",
     "cartopy",
     "colorcet",
     "cutde>=25.7.24",


### PR DESCRIPTION
## Why

`pyproject.toml` declared `arviz` with **no version bound**, so `pip install celeri` resolves the latest ArviZ — currently **1.2.0**. But celeri is developed and tested against ArviZ **0.x**: the conda env in `pixi.toml` already pins `arviz = "<1.0.0"`, and the test suite runs against **0.23.4**. ArviZ 1.x is a backward-incompatible refactor (celeri isn't compliant yet), so the **published wheel can break on import paths CI never exercises** — the test environment and a real `pip install` were resolving different majors.

This surfaced while checking what the release pipeline's wheel-install job (#472) actually pulls:

| package | pixi.lock (dev/test) | wheel (`pip`, before this PR) |
|---|---|---|
| **ArviZ** | **0.23.4** | **1.2.0** |
| PyMC | 5.28.5 | 6.0.1 |
| PyTensor | 2.38.3 | 3.0.7 |

## What

- `pyproject.toml`: `arviz` → `arviz<1.0.0`, matching the ceiling already in `pixi.toml`, so wheel installs resolve the same supported major as the tested environment.
- `pixi.lock`: regenerated (isolated commit) — the only change is `celeri`'s `requires_dist` entry (`arviz` → `arviz<1.0.0`); the resolved ArviZ stays 0.23.4.

## Scope

Deliberately caps **only ArviZ**. PyMC (6.0.1) and PyTensor (3.0.7) are also unbounded in `pyproject.toml` and likewise float ahead of the tested 5.x/2.x — worth a follow-up, but out of scope here.

---
> 🤖 AI-assisted (Claude Code) at the request of @maresb.

Closes #476