### PR TITLE
Fix mcmc_draw crash on divergent samples (closes #475)

### DIFF
--- a/celeri/solve.py
+++ b/celeri/solve.py
@@ -754,9 +754,9 @@ class Estimation:
             dim for dim in ("draw", "chain") if dim in subsetted_trace.posterior.dims
         ]
 
-        trace_for_state = subsetted_trace.mean(dims_to_mean)
+        posterior_point = subsetted_trace.posterior.mean(dims_to_mean)
         state_vector = _state_vector_from_draw(
-            self.model, self.operators, trace_for_state
+            self.model, self.operators, posterior_point
         )
         return replace(self, state_vector=state_vector, mcmc_trace=subsetted_trace)
 

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -1780,9 +1780,8 @@ def solve_mcmc(
         compile_kwargs={"mode": backend_mode},
     )
 
-    state_vector = _state_vector_from_draw(
-        model, operators, trace.mean(["chain", "draw"])
-    )
+    posterior_point = trace.posterior.mean(["chain", "draw"])
+    state_vector = _state_vector_from_draw(model, operators, posterior_point)
     estimation = build_estimation(model, operators, state_vector)
     estimation.mcmc_trace = trace
     estimation.mcmc_start_time = mcmc_start_time.isoformat()
@@ -1795,9 +1794,14 @@ def solve_mcmc(
 def _state_vector_from_draw(
     model: Model,
     operators: Operators,
-    trace,
+    posterior_point,
 ):
-    """Build a state vector from MCMC trace using eigen coefficients.
+    """Build a state vector from a single posterior point using eigen coefficients.
+
+    ``posterior_point`` is the ``posterior`` group of an MCMC trace (an xarray
+    ``Dataset``) reduced to a single point over ``draw``/``chain`` by the
+    caller: the mean of the selected draws/chains, or one sample when a single
+    draw and chain are chosen.
 
     The state vector uses eigen coefficients (not TDE values) so that
     Estimation.predictions uses eigen_to_velocities for forward predictions.
@@ -1814,15 +1818,15 @@ def _state_vector_from_draw(
 
     start = operators.index.start_block_strain_col
     end = operators.index.end_block_strain_col
-    state_vector[start:end] = trace.posterior.block_strain_rate.values
+    state_vector[start:end] = posterior_point.block_strain_rate.values
 
     start = operators.index.start_mogi_col
     end = operators.index.end_mogi_col
-    state_vector[start:end] = trace.posterior.mogi.values
+    state_vector[start:end] = posterior_point.mogi.values
 
     start = operators.index.start_block_col
     end = operators.index.end_block_col
-    state_vector[start:end] = trace.posterior.rotation.values
+    state_vector[start:end] = posterior_point.rotation.values
 
     # Extract eigen coefficients for each mesh
     for mesh_idx in range(len(model.meshes)):
@@ -1841,12 +1845,12 @@ def _state_vector_from_draw(
             elastic_eigen_var = f"elastic_eigen_{mesh_idx}_{kind_short}"
             elastic_tde_var = f"elastic_{mesh_idx}_{kind_short}"
 
-            if elastic_eigen_var in trace.posterior:
-                coefs[coef_start : coef_start + n_modes] = trace.posterior[
+            if elastic_eigen_var in posterior_point:
+                coefs[coef_start : coef_start + n_modes] = posterior_point[
                     elastic_eigen_var
                 ].values
-            elif elastic_tde_var in trace.posterior:
-                elastic_tde = trace.posterior[elastic_tde_var].values
+            elif elastic_tde_var in posterior_point:
+                elastic_tde = posterior_point[elastic_tde_var].values
                 eigenvectors = _get_eigenmodes(model, mesh_idx, kind)
                 coefs[coef_start : coef_start + n_modes] = eigenvectors.T @ elastic_tde
 


### PR DESCRIPTION
Fixes #475.

This is a straightforward fix for an occasional crash triggered by an interaction between nutpie and celeri due to recent changes in nutpie. This shouldn't affect any results.

---

## Problem

`Estimation.mcmc_draw` (and the estimation build in `solve_mcmc`) averaged the **whole** `InferenceData` (`subsetted_trace.mean(...)`), including the `sample_stats` group. Since **nutpie ≥ 0.16.9** stores an object-dtype divergence message there (e.g. `'Divergence due to large energy error: 5280.9373'`), selecting a divergent draw tried to take the `mean()` of that string and raised:

```
ValueError: could not convert string to float: 'Divergence due to large energy error: ...'
```

It surfaced as an intermittent failure of `test_mcmc_selection` (it only fires when a draw diverges) and flaked across #466, #472 and #479. See #475 for the full root-cause provenance.

## Fix

Average **only the `posterior` group** (the only thing `_state_vector_from_draw` reads) at both call sites. `_state_vector_from_draw` now takes the posterior `Dataset` (`posterior_point`) directly. The resulting `state_vector` is identical; we simply stop reducing groups we never use, so `sample_stats` is never touched.

No new test: this de-flakes the existing `test_mcmc_selection` (it no longer crashes when a real divergence lands), and the change is an obviously-correct refactor.

---
> 🤖 AI-assisted (Claude Code) at the request of @maresb.
