### PR TITLE
Default coupling prior mean to 0.5

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -299,7 +299,7 @@ class Config(RelativePathSerializerMixin, BaseModel):
     # unconstrained space. For coupling with bounds [0, 1], constrained mean 0.5
     # is at the center. For elastic with one-sided bounds, unconstrained mean 0
     # places the constrained mean at ±softplus_lengthscale.
-    mcmc_default_mesh_coupling_mean: float = 0.9
+    mcmc_default_mesh_coupling_mean: float = 0.5
     """Default prior mean for coupling field (dimensionless, in (0, 1))."""
 
     mcmc_default_mesh_coupling_mean_parameterization: McmcMeanParameterization = (


### PR DESCRIPTION
## Summary

Changes the default MCMC coupling prior mean (`Config.mcmc_default_mesh_coupling_mean`) from `0.9` to `0.5`.

This way the default prior is minimally committal between creep and full coupling rather than biased toward full coupling.

Mesh-specific `coupling_mean` values continue to override this default, so only runs that rely on the default are affected.

## Change

- `celeri/config.py`: `mcmc_default_mesh_coupling_mean: 0.9 → 0.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)