### PR TITLE
minor lint: consolidate imports in test file

### DIFF
--- a/tests/okada/test_okada.py
+++ b/tests/okada/test_okada.py
@@ -4,16 +4,16 @@ import warnings
 import numpy as np
 import pytest
 
-HAS_OKADA_WRAPPER = importlib.util.find_spec("okada_wrapper") is not None
-requires_okada_wrapper = pytest.mark.skipif(
-    not HAS_OKADA_WRAPPER,
-    reason="optional okada_wrapper package is not installed",
-)
-
 from celeri.okada.cutde_okada import (
     _determine_auto_triangulation,
     _preprocess_obs_pts,
     dc3dwrapper_cutde_disp,
+)
+
+HAS_OKADA_WRAPPER = importlib.util.find_spec("okada_wrapper") is not None
+requires_okada_wrapper = pytest.mark.skipif(
+    not HAS_OKADA_WRAPPER,
+    reason="optional okada_wrapper package is not installed",
 )
 
 


### PR DESCRIPTION
This just affects a pytest file. Automated linters like to see imports grouped together, and this PR does just that. No functional changes, but keeps the signal-to-noise ratio high for those who secretly and obsessively run such tools.

---

`tests/okada/test_okada.py` trips ruff **E402** (module import not at top of file) on `main`.

### Cause
Commit c2da262 ("Make okada_wrapper an optional dependency") inserted the `HAS_OKADA_WRAPPER` / `requires_okada_wrapper` guard *between* the third-party imports and the `from celeri.okada.cutde_okada import ...` block, displacing that import downward.

### Why the placement is safe to change
The displaced import is `cutde_okada` — **not** `okada_wrapper`:
- `cutde_okada` imports `okada_wrapper` only lazily, inside a function (`cutde_okada.py:263`).
- `importlib.util.find_spec("okada_wrapper")` imports nothing.

So the import runs fine at the top regardless of whether the optional `okada_wrapper` is installed; the previous placement offered no protection. This moves it back up with the other imports, leaving the guard assignments below.

No behavior change; test collection is unaffected (363 tests collect, ruff + ruff-format clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)