### PR TITLE
Never materialize the dense per-mesh TDE matrix in streaming eigen operator construction

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -91,6 +91,17 @@ class Config(RelativePathSerializerMixin, BaseModel):
     force_recompute: bool = False
     """When True, recomputes all operators even if cached versions are present."""
 
+    tde_operator_memory_gb: float = 1.0
+    """Approximate memory budget in gigabytes for transient blocks of the dense
+    TDE elastic operator during operator construction.
+
+    In streaming MCMC mode (mcmc_station_velocity_method="project_to_eigen") the
+    per-mesh (3 * n_stations, 3 * n_triangles) TDE matrix is never fully
+    materialized; triangle-column and station-row slabs of roughly this size are
+    processed one at a time. Peak transient memory is about 1.7x this value.
+    Larger values are faster; results are unchanged up to floating-point
+    round-off."""
+
     # Weights for various constraints and parameters in penalized linear inversion
     block_constraint_weight: float = 1e24
     slip_constraint_weight: float = 100000

--- a/celeri/operators.py
+++ b/celeri/operators.py
@@ -70,6 +70,7 @@ from celeri.spatial import (
     get_rotation_to_slip_rate_partials,
     get_rotation_to_velocities_partials,
     get_segment_station_operator_okada,
+    get_tde_displacement_slab_single_mesh,
     get_tde_to_velocities_single_mesh,
     get_tri_smoothing_matrix,
 )
@@ -1110,29 +1111,74 @@ def build_los_operators(
     # TDE operators at LOS locations
     tde_to_los: dict[int, np.ndarray] = {}
     eigen_to_los: dict[int, np.ndarray] = {}
-    tde_n_cols: dict[int, int] = {}
 
     if operators.tde is not None:
+        obs_lon = los.lon.to_numpy()
+        obs_lat = los.lat.to_numpy()
+        target_bytes = int(model.config.tde_operator_memory_gb * 2**30)
+        # When tde_to_los would be discarded anyway, accumulate eigen_to_los
+        # per triangle chunk and never hold a mesh's full tde_to_los
+        stream_only_eigen = discard_tde_to_los and operators.eigen is not None
         for mesh_idx in range(len(model.meshes)):
-            tde_to_velocities = get_tde_to_velocities_single_mesh(
-                model.meshes, los, model.config, mesh_idx
-            )
-            tde_to_los[mesh_idx] = _project_operator_to_los(
-                tde_to_velocities, look_vectors
-            )
-            tde_n_cols[mesh_idx] = tde_to_velocities.shape[1]
-
-        if operators.eigen is not None:
-            for mesh_idx in range(len(model.meshes)):
-                # eigen_to_los = tde_to_los @ eigenvectors
-                # The eigenvectors map from eigenmode coefficients to TDE slip rates
-                tde_los_op = tde_to_los[mesh_idx]
-                # Slice columns to keep only strike-slip and dip-slip (exclude tensile)
-                tde_keep_col_index = get_keep_index_12(tde_n_cols[mesh_idx])
-                tde_los_ss_ds = tde_los_op[:, tde_keep_col_index]
+            n_tris = model.meshes[mesh_idx].lon1.size
+            tri_batch_size = _tde_tri_batch_size(target_bytes, n_los, n_tris)
+            if stream_only_eigen:
+                assert operators.eigen is not None
                 eigenvectors = operators.eigen.eigenvectors_to_tde_slip[mesh_idx]
-                # Note: negative sign because elastic velocity is opposite to slip
-                eigen_to_los[mesh_idx] = -tde_los_ss_ds @ eigenvectors
+                assert eigenvectors.shape[0] == 2 * n_tris
+                # eigen_to_los = -tde_to_los[:, keep_12] @ eigenvectors
+                # The eigenvectors map from eigenmode coefficients to TDE slip
+                # rates; negative sign because elastic velocity is opposite to
+                # slip
+                out = np.zeros((n_los, eigenvectors.shape[1]))
+                for t0 in track(
+                    range(0, n_tris, tri_batch_size),
+                    description="LOS surface elastic        ",
+                ):
+                    t1 = min(t0 + tri_batch_size, n_tris)
+                    slab = get_tde_displacement_slab_single_mesh(
+                        obs_lon,
+                        obs_lat,
+                        model.meshes,
+                        model.config.material_lambda,
+                        model.config.material_mu,
+                        mesh_idx=mesh_idx,
+                        tri_start=t0,
+                        tri_stop=t1,
+                    )
+                    slab_los = _project_operator_to_los(slab, look_vectors)
+                    keep_local = get_keep_index_12(slab_los.shape[1])
+                    out -= slab_los[:, keep_local] @ eigenvectors[2 * t0 : 2 * t1, :]
+                eigen_to_los[mesh_idx] = out
+            else:
+                tde_los = np.empty((n_los, 3 * n_tris))
+                for t0 in track(
+                    range(0, n_tris, tri_batch_size),
+                    description="LOS surface elastic        ",
+                ):
+                    t1 = min(t0 + tri_batch_size, n_tris)
+                    slab = get_tde_displacement_slab_single_mesh(
+                        obs_lon,
+                        obs_lat,
+                        model.meshes,
+                        model.config.material_lambda,
+                        model.config.material_mu,
+                        mesh_idx=mesh_idx,
+                        tri_start=t0,
+                        tri_stop=t1,
+                    )
+                    tde_los[:, 3 * t0 : 3 * t1] = _project_operator_to_los(
+                        slab, look_vectors
+                    )
+                tde_to_los[mesh_idx] = tde_los
+                if operators.eigen is not None:
+                    # Note: negative sign because elastic velocity is opposite
+                    # to slip
+                    eigen_to_los[mesh_idx] = _project_tde_rows_to_eigen(
+                        tde_los,
+                        operators.eigen.eigenvectors_to_tde_slip[mesh_idx],
+                        target_bytes,
+                    )
 
     los_data = np.asarray(los.los_val.values)
 
@@ -1352,6 +1398,73 @@ def _compare_segments(
     return changed_indices
 
 
+def _compute_and_cache_tde_to_velocities(
+    meshes: list[Mesh],
+    station: DataFrame,
+    config: Config,
+    operators: _OperatorBuilder,
+    cache: Path | None,
+):
+    """Compute dense tde_to_velocities for every mesh and optionally append the
+    datasets to an existing cache file (preserving its other datasets).
+    """
+    for i in range(len(meshes)):
+        logger.info(
+            f"Start: TDE slip to velocity calculation for mesh: {meshes[i].file_name}"
+        )
+        operators.tde_to_velocities[i] = get_tde_to_velocities_single_mesh(
+            meshes, station, config, mesh_idx=i
+        )
+        logger.success(
+            f"Finish: TDE slip to velocity calculation for mesh: {meshes[i].file_name}"
+        )
+    if cache is not None:
+        logger.info("Adding tde_to_velocities to cache")
+        with h5py.File(str(cache), "a") as hdf5_file:
+            for i in range(len(meshes)):
+                key = "tde_to_velocities_" + str(i)
+                if key in hdf5_file:
+                    del hdf5_file[key]
+                hdf5_file.create_dataset(key, data=operators.tde_to_velocities[i])
+
+
+def _write_elastic_operator_cache(
+    cache: Path,
+    operators: _OperatorBuilder,
+    segment: DataFrame,
+    meshes: list[Mesh],
+    *,
+    write_tde: bool,
+    preserve_existing_tde: bool,
+):
+    """Write the okada operator and segment metadata (and optionally the dense
+    TDE matrices) to the cache file.
+
+    When preserve_existing_tde is True the file is updated in place so that
+    tde_to_velocities_<i> datasets written by other (non-streaming) runs
+    survive a rewrite triggered while streaming — those datasets stay valid
+    because the cache hash covers stations, meshes, and material parameters
+    but not segments. HDF5 does not reclaim the space of replaced datasets;
+    use h5repack to compact a cache file if it grows.
+    """
+    mode = "a" if preserve_existing_tde and cache.exists() else "w"
+    with h5py.File(str(cache), mode) as hdf5_file:
+        for key in ("slip_rate_to_okada_to_velocities", "segments", "segments_names"):
+            if key in hdf5_file:
+                del hdf5_file[key]
+        hdf5_file.create_dataset(
+            "slip_rate_to_okada_to_velocities",
+            data=operators.slip_rate_to_okada_to_velocities,
+        )
+        if write_tde:
+            for i in range(len(meshes)):
+                key = "tde_to_velocities_" + str(i)
+                if key in hdf5_file:
+                    del hdf5_file[key]
+                hdf5_file.create_dataset(key, data=operators.tde_to_velocities[i])
+        _save_segments_to_hdf5(segment, hdf5_file)
+
+
 def _store_elastic_operators(
     model: Model,
     operators: _OperatorBuilder,
@@ -1439,11 +1552,16 @@ def _store_elastic_operators(
                                 hdf5_file.close()
                                 return
                             hdf5_file.close()
+                            # Streaming runs cache the okada operator but not
+                            # the dense TDE matrices, so a later non-streaming
+                            # run lands here and must compute them
                             logger.info(
                                 "Cache missing tde_to_velocities. Computing from scratch."
                             )
-                        else:
-                            return
+                            _compute_and_cache_tde_to_velocities(
+                                meshes, station, config, operators, cache
+                            )
+                        return
 
                     logger.info(f"Recomputing {len(changed_segment_indices)} segments")
 
@@ -1476,22 +1594,24 @@ def _store_elastic_operators(
                                 )
                             tde_loaded_from_cache = True
                         hdf5_file.close()
+                        if not tde_loaded_from_cache:
+                            logger.info(
+                                "Cache missing tde_to_velocities. Computing from scratch."
+                            )
+                            _compute_and_cache_tde_to_velocities(
+                                meshes, station, config, operators, cache=None
+                            )
 
                     logger.info("Caching updated elastic operators")
                     cache.parent.mkdir(parents=True, exist_ok=True)
-                    hdf5_file = h5py.File(str(cache), "w")
-                    hdf5_file.create_dataset(
-                        "slip_rate_to_okada_to_velocities",
-                        data=operators.slip_rate_to_okada_to_velocities,
+                    _write_elastic_operator_cache(
+                        cache,
+                        operators,
+                        segment,
+                        meshes,
+                        write_tde=tde and not skip_tde_to_velocities,
+                        preserve_existing_tde=skip_tde_to_velocities,
                     )
-                    if tde and tde_loaded_from_cache:
-                        for i in range(len(meshes)):
-                            hdf5_file.create_dataset(
-                                "tde_to_velocities_" + str(i),
-                                data=operators.tde_to_velocities[i],
-                            )
-                    _save_segments_to_hdf5(segment, hdf5_file)
-                    hdf5_file.close()
 
                     return
 
@@ -1527,20 +1647,14 @@ def _store_elastic_operators(
         return
     logger.info("Saving elastic operators in cache")
     cache.parent.mkdir(parents=True, exist_ok=True)
-    hdf5_file = h5py.File(str(cache), "w")
-
-    hdf5_file.create_dataset(
-        "slip_rate_to_okada_to_velocities",
-        data=operators.slip_rate_to_okada_to_velocities,
+    _write_elastic_operator_cache(
+        cache,
+        operators,
+        segment,
+        meshes,
+        write_tde=tde and not skip_tde_to_velocities,
+        preserve_existing_tde=skip_tde_to_velocities,
     )
-    if tde and not skip_tde_to_velocities:
-        for i in range(len(meshes)):
-            hdf5_file.create_dataset(
-                "tde_to_velocities_" + str(i),
-                data=operators.tde_to_velocities[i],
-            )
-    _save_segments_to_hdf5(segment, hdf5_file)
-    hdf5_file.close()
 
 
 def _store_all_mesh_smoothing_matrices(model: Model, operators: _OperatorBuilder):
@@ -2638,25 +2752,121 @@ def _store_eigenvectors_to_tde_slip(model: Model, operators: _OperatorBuilder):
         logger.success(f"Finish: Eigenvectors to TDE slip for mesh: {mesh.file_name}")
 
 
+def _tde_tri_batch_size(target_bytes: int, n_obs: int, n_tris: int) -> int:
+    """Triangles per slab chunk: one column-triple costs 3 * n_obs rows *
+    3 columns * 8 bytes.
+    """
+    return max(1, min(n_tris, target_bytes // (72 * max(1, n_obs))))
+
+
+def _project_tde_rows_to_eigen(
+    tde_to_velocities, eigenvectors_to_tde_slip: np.ndarray, target_bytes: int
+) -> np.ndarray:
+    """Compute -tde_to_velocities[:, keep_12] @ eigenvectors_to_tde_slip in row batches.
+
+    tde_to_velocities may be an np.ndarray or an open h5py.Dataset of shape
+    (3 * n_stations, 3 * n_tris). Processing station-row slabs of at most
+    target_bytes avoids materializing the (3 * n_stations, 2 * n_tris)
+    kept-column copy that a direct fancy-index would create (and, for an
+    h5py.Dataset, avoids loading the full matrix at all).
+    """
+    n_rows, n_cols = tde_to_velocities.shape
+    assert eigenvectors_to_tde_slip.shape[0] == 2 * (n_cols // 3)
+    # Slice columns to only strike-slip and dip-slip (exclude tensile)
+    tde_keep_col_index = get_keep_index_12(n_cols)
+    out = np.empty((n_rows, eigenvectors_to_tde_slip.shape[1]))
+    rows_per_batch = max(1, target_bytes // max(1, 8 * n_cols))
+    for r0 in range(0, n_rows, rows_per_batch):
+        r1 = min(r0 + rows_per_batch, n_rows)
+        # Contiguous row read (cheap for h5py, a view for ndarray); only the
+        # small in-memory slab is fancy-indexed
+        slab = np.asarray(tde_to_velocities[r0:r1, :])
+        out[r0:r1, :] = -(slab[:, tde_keep_col_index] @ eigenvectors_to_tde_slip)
+    return out
+
+
+def _accumulate_eigen_to_velocities_streaming(
+    meshes: list[Mesh],
+    station: DataFrame,
+    config: Config,
+    mesh_idx: int,
+    eigenvectors_to_tde_slip: np.ndarray,
+    target_bytes: int,
+    tri_batch_size: int | None = None,
+) -> np.ndarray:
+    """Accumulate -tde_to_velocities[:, keep_12] @ eigenvectors_to_tde_slip over
+    triangle chunks without ever materializing the dense TDE matrix.
+
+    For each chunk of triangles [t0, t1), the displacement slab
+    (3 * n_stations, 3 * (t1 - t0)) pairs with rows [2*t0, 2*t1) of
+    eigenvectors_to_tde_slip: kept slab column 2*j is strike slip of triangle
+    t0 + j and matches row 2*j of the slice, kept column 2*j + 1 is dip slip
+    and matches row 2*j + 1. Tensile columns are computed in each slab (they
+    come for free from cutde) but are not projected, matching the dense path.
+    """
+    assert not station.empty
+    n_tris = meshes[mesh_idx].lon1.size
+    n_obs = len(station)
+    assert eigenvectors_to_tde_slip.shape[0] == 2 * n_tris
+    out = np.zeros((3 * n_obs, eigenvectors_to_tde_slip.shape[1]))
+    if tri_batch_size is None:
+        tri_batch_size = _tde_tri_batch_size(target_bytes, n_obs, n_tris)
+    tri_batch_size = max(1, min(n_tris, tri_batch_size))
+    obs_lon = station.lon.to_numpy()
+    obs_lat = station.lat.to_numpy()
+    slab_buffer = np.empty((3 * n_obs, 3 * tri_batch_size))
+    keep_full = get_keep_index_12(slab_buffer.shape[1])
+    for t0 in track(
+        range(0, n_tris, tri_batch_size), description="Meshed surface elastic     "
+    ):
+        t1 = min(t0 + tri_batch_size, n_tris)
+        slab = get_tde_displacement_slab_single_mesh(
+            obs_lon,
+            obs_lat,
+            meshes,
+            config.material_lambda,
+            config.material_mu,
+            mesh_idx=mesh_idx,
+            tri_start=t0,
+            tri_stop=t1,
+            out=slab_buffer[:, : 3 * (t1 - t0)],
+        )
+        keep_local = (
+            keep_full if t1 - t0 == tri_batch_size else get_keep_index_12(slab.shape[1])
+        )
+        out -= slab[:, keep_local] @ eigenvectors_to_tde_slip[2 * t0 : 2 * t1, :]
+    return out
+
+
 def _compute_eigen_to_velocities(
     model: Model, operators: _OperatorBuilder, index: Index, streaming: bool
 ) -> dict[int, np.ndarray]:
     """Compute eigen_to_velocities for all meshes.
 
     Args:
-        streaming: If True, processes one mesh at a time by loading/computing
-            tde_to_velocities on demand, adding the result to the cache file, then
-            discarding it before moving to the next mesh. This reduces peak memory
-            usage from O(n_meshes * tde_matrix_size) to O(tde_matrix_size).
-            If False, uses the pre-computed operators.tde_to_velocities.
+        streaming: If True, processes one mesh at a time without ever
+            materializing the dense per-mesh TDE matrix. If the elastic
+            operator cache holds tde_to_velocities for a mesh, it is projected
+            in station-row slabs read directly from the HDF5 dataset;
+            otherwise the projection is accumulated over triangle chunks
+            computed on the fly. Peak transient memory is
+            O(config.tde_operator_memory_gb) instead of O(tde_matrix_size).
+            Streaming mode does not write dense TDE matrices to the cache
+            file.
+            If False, uses the pre-computed operators.tde_to_velocities
+            (projected in row batches to avoid a full kept-column copy).
 
     Returns:
         Dictionary mapping mesh index to eigen_to_velocities operator.
-        Each operator has shape (2 * n_stations, n_modes_ss + n_modes_ds).
+        Each operator has shape (3 * n_stations, n_modes_ss + n_modes_ds).
+        All 3 velocity components are kept; station_row_keep_index handles the
+        vertical flag when the operator is inserted into the full operator.
     """
     config = model.config
     meshes = model.meshes
     station = model.station
+
+    target_bytes = int(config.tde_operator_memory_gb * 2**30)
 
     cache = None
     if streaming and config.elastic_operator_cache_dir is not None:
@@ -2670,48 +2880,34 @@ def _compute_eigen_to_velocities(
     eigen_to_velocities: dict[int, np.ndarray] = {}
 
     for i in range(index.n_meshes):
-        tde_computed = False
+        eigenvectors_to_tde_slip = operators.eigenvectors_to_tde_slip[i]
+        result = None
         if streaming:
-            logger.info(f"Loading tde_to_velocities for mesh: {meshes[i].file_name}")
-
-            tde_to_velocities = None
             if cache is not None and cache.exists():
-                hdf5_file = h5py.File(str(cache), "r")
-                cached_data = hdf5_file.get("tde_to_velocities_" + str(i))
-                if cached_data is not None:
-                    tde_to_velocities = np.array(cached_data)
-                hdf5_file.close()
-
-            if tde_to_velocities is None:
-                tde_to_velocities = get_tde_to_velocities_single_mesh(
-                    meshes, station, config, mesh_idx=i
+                with h5py.File(str(cache), "r") as hdf5_file:
+                    cached_data = hdf5_file.get("tde_to_velocities_" + str(i))
+                    if cached_data is not None:
+                        logger.info(
+                            "Projecting cached tde_to_velocities for mesh: "
+                            f"{meshes[i].file_name}"
+                        )
+                        result = _project_tde_rows_to_eigen(
+                            cached_data, eigenvectors_to_tde_slip, target_bytes
+                        )
+            if result is None:
+                logger.info(
+                    f"Computing eigen_to_velocities for mesh: {meshes[i].file_name}"
                 )
-                tde_computed = True
+                result = _accumulate_eigen_to_velocities_streaming(
+                    meshes, station, config, i, eigenvectors_to_tde_slip, target_bytes
+                )
         else:
             tde_to_velocities = operators.tde_to_velocities[i]
-
-        assert tde_to_velocities is not None and tde_to_velocities.ndim == 2
-        # Slice columns to only strike-slip and dip-slip (exclude tensile)
-        tde_keep_col_index = get_keep_index_12(tde_to_velocities.shape[1])  # type: ignore[index]
-
-        # Create eigenvector to velocities operator
-        # Keep all 3 velocity components; use station_row_keep_index when
-        # inserting into the full operator to handle vertical flag
-        eigen_to_velocities[i] = (
-            -tde_to_velocities[:, tde_keep_col_index]
-            @ operators.eigenvectors_to_tde_slip[i]
-        )
-
-        if streaming:
-            if tde_computed and cache is not None:
-                logger.info(f"Saving tde_to_velocities to cache: {cache}")
-                cache.parent.mkdir(parents=True, exist_ok=True)
-                hdf5_file = h5py.File(str(cache), "a")
-                key = "tde_to_velocities_" + str(i)
-                if hdf5_file.get(key) is None:
-                    hdf5_file.create_dataset(key, data=tde_to_velocities)
-                hdf5_file.close()
-            del tde_to_velocities
+            assert tde_to_velocities is not None and tde_to_velocities.ndim == 2
+            result = _project_tde_rows_to_eigen(
+                tde_to_velocities, eigenvectors_to_tde_slip, target_bytes
+            )
+        eigen_to_velocities[i] = result
 
     return eigen_to_velocities
 

--- a/celeri/spatial.py
+++ b/celeri/spatial.py
@@ -475,62 +475,21 @@ def get_tde_to_velocities(meshes, station, config):
         n_tris = meshes[0].lon1.size
         if not station.empty:
             tri_operator = np.zeros((3 * len(station), 3 * n_tris))
+            obs_lon = station.lon.to_numpy()
+            obs_lat = station.lat.to_numpy()
 
             for i in track(range(n_tris), description="Meshed surface elastic     "):
-                (
-                    vel_east_strike_slip,
-                    vel_north_strike_slip,
-                    vel_up_strike_slip,
-                ) = get_tri_displacements(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
+                get_tde_displacement_slab_single_mesh(
+                    obs_lon,
+                    obs_lat,
                     meshes,
                     config.material_lambda,
                     config.material_mu,
-                    tri_idx=i,
-                    strike_slip=1,
-                    dip_slip=0,
-                    tensile_slip=0,
+                    mesh_idx=0,
+                    tri_start=i,
+                    tri_stop=i + 1,
+                    out=tri_operator[:, 3 * i : 3 * i + 3],
                 )
-                (
-                    vel_east_dip_slip,
-                    vel_north_dip_slip,
-                    vel_up_dip_slip,
-                ) = get_tri_displacements(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
-                    meshes,
-                    config.material_lambda,
-                    config.material_mu,
-                    tri_idx=i,
-                    strike_slip=0,
-                    dip_slip=1,
-                    tensile_slip=0,
-                )
-                (
-                    vel_east_tensile_slip,
-                    vel_north_tensile_slip,
-                    vel_up_tensile_slip,
-                ) = get_tri_displacements(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
-                    meshes,
-                    config.material_lambda,
-                    config.material_mu,
-                    tri_idx=i,
-                    strike_slip=0,
-                    dip_slip=0,
-                    tensile_slip=1,
-                )
-                tri_operator[0::3, 3 * i] = np.squeeze(vel_east_strike_slip)
-                tri_operator[1::3, 3 * i] = np.squeeze(vel_north_strike_slip)
-                tri_operator[2::3, 3 * i] = np.squeeze(vel_up_strike_slip)
-                tri_operator[0::3, 3 * i + 1] = np.squeeze(vel_east_dip_slip)
-                tri_operator[1::3, 3 * i + 1] = np.squeeze(vel_north_dip_slip)
-                tri_operator[2::3, 3 * i + 1] = np.squeeze(vel_up_dip_slip)
-                tri_operator[0::3, 3 * i + 2] = np.squeeze(vel_east_tensile_slip)
-                tri_operator[1::3, 3 * i + 2] = np.squeeze(vel_north_tensile_slip)
-                tri_operator[2::3, 3 * i + 2] = np.squeeze(vel_up_tensile_slip)
         else:
             tri_operator = np.empty(0)
     else:
@@ -562,66 +521,23 @@ def get_tde_to_velocities_single_mesh(meshes, station, config, mesh_idx):
         n_tris = meshes[mesh_idx].lon1.size
         if not station.empty:
             tri_operator = np.zeros((3 * len(station), 3 * n_tris))
+            obs_lon = station.lon.to_numpy()
+            obs_lat = station.lat.to_numpy()
 
-            # Loop through each segment and calculate displacements for each slip component
+            # Loop through each triangle and calculate displacements for all
+            # three slip components with a single cutde call
             for i in track(range(n_tris), description="Meshed surface elastic     "):
-                (
-                    vel_east_strike_slip,
-                    vel_north_strike_slip,
-                    vel_up_strike_slip,
-                ) = get_tri_displacements_single_mesh(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
+                get_tde_displacement_slab_single_mesh(
+                    obs_lon,
+                    obs_lat,
                     meshes,
                     config.material_lambda,
                     config.material_mu,
-                    tri_idx=i,
-                    strike_slip=1,
-                    dip_slip=0,
-                    tensile_slip=0,
                     mesh_idx=mesh_idx,
+                    tri_start=i,
+                    tri_stop=i + 1,
+                    out=tri_operator[:, 3 * i : 3 * i + 3],
                 )
-                (
-                    vel_east_dip_slip,
-                    vel_north_dip_slip,
-                    vel_up_dip_slip,
-                ) = get_tri_displacements_single_mesh(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
-                    meshes,
-                    config.material_lambda,
-                    config.material_mu,
-                    tri_idx=i,
-                    strike_slip=0,
-                    dip_slip=1,
-                    tensile_slip=0,
-                    mesh_idx=mesh_idx,
-                )
-                (
-                    vel_east_tensile_slip,
-                    vel_north_tensile_slip,
-                    vel_up_tensile_slip,
-                ) = get_tri_displacements_single_mesh(
-                    station.lon.to_numpy(),
-                    station.lat.to_numpy(),
-                    meshes,
-                    config.material_lambda,
-                    config.material_mu,
-                    tri_idx=i,
-                    strike_slip=0,
-                    dip_slip=0,
-                    tensile_slip=1,
-                    mesh_idx=mesh_idx,
-                )
-                tri_operator[0::3, 3 * i] = np.squeeze(vel_east_strike_slip)
-                tri_operator[1::3, 3 * i] = np.squeeze(vel_north_strike_slip)
-                tri_operator[2::3, 3 * i] = np.squeeze(vel_up_strike_slip)
-                tri_operator[0::3, 3 * i + 1] = np.squeeze(vel_east_dip_slip)
-                tri_operator[1::3, 3 * i + 1] = np.squeeze(vel_north_dip_slip)
-                tri_operator[2::3, 3 * i + 1] = np.squeeze(vel_up_dip_slip)
-                tri_operator[0::3, 3 * i + 2] = np.squeeze(vel_east_tensile_slip)
-                tri_operator[1::3, 3 * i + 2] = np.squeeze(vel_north_tensile_slip)
-                tri_operator[2::3, 3 * i + 2] = np.squeeze(vel_up_tensile_slip)
         else:
             tri_operator = np.empty(0)
     else:
@@ -644,34 +560,18 @@ def get_tri_displacements(
     element in a half space.  Includes projection from longitude and
     latitude to locally tangent planar coordinate system.
     """
-    poissons_ratio = material_mu / (2 * (material_mu + material_lambda))
-
-    # Project coordinates
-    tri_centroid_lon = meshes[0].centroids[tri_idx, 0]
-    tri_centroid_lat = meshes[0].centroids[tri_idx, 1]
-    projection = get_transverse_projection(tri_centroid_lon, tri_centroid_lat)
-    obs_x, obs_y = projection(obs_lon, obs_lat)
-    tri_x1, tri_y1 = projection(meshes[0].lon1[tri_idx], meshes[0].lat1[tri_idx])
-    tri_x2, tri_y2 = projection(meshes[0].lon2[tri_idx], meshes[0].lat2[tri_idx])
-    tri_x3, tri_y3 = projection(meshes[0].lon3[tri_idx], meshes[0].lat3[tri_idx])
-    tri_z1 = KM2M * meshes[0].dep1[tri_idx]
-    tri_z2 = KM2M * meshes[0].dep2[tri_idx]
-    tri_z3 = KM2M * meshes[0].dep3[tri_idx]
-
-    # Package coordinates for cutde call
-    obs_coords = np.vstack((obs_x, obs_y, np.zeros_like(obs_x))).T
-    tri_coords = np.array(
-        [[tri_x1, tri_y1, tri_z1], [tri_x2, tri_y2, tri_z2], [tri_x3, tri_y3, tri_z3]]
+    block = get_tde_displacement_slab_single_mesh(
+        obs_lon,
+        obs_lat,
+        meshes,
+        material_lambda,
+        material_mu,
+        mesh_idx=0,
+        tri_start=tri_idx,
+        tri_stop=tri_idx + 1,
     )
-
-    # Call cutde, multiply by displacements, and package for the return
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        disp_mat = cutde_halfspace.disp_matrix(
-            obs_pts=obs_coords, tris=np.array([tri_coords]), nu=poissons_ratio
-        )
-    slip = np.array([[strike_slip, dip_slip, tensile_slip]])
-    disp = disp_mat.reshape((-1, 3)).dot(slip.flatten())
+    slip = np.array([strike_slip, dip_slip, tensile_slip], dtype=np.float64)
+    disp = block @ slip
     vel_east = disp[0::3]
     vel_north = disp[1::3]
     vel_up = disp[2::3]
@@ -694,44 +594,91 @@ def get_tri_displacements_single_mesh(
     element in a half space.  Includes projection from longitude and
     latitude to locally tangent planar coordinate system.
     """
-    poissons_ratio = material_mu / (2 * (material_mu + material_lambda))
-
-    # Project coordinates
-    tri_centroid_lon = meshes[mesh_idx].centroids[tri_idx, 0]
-    tri_centroid_lat = meshes[mesh_idx].centroids[tri_idx, 1]
-    projection = get_transverse_projection(tri_centroid_lon, tri_centroid_lat)
-    obs_x, obs_y = projection(obs_lon, obs_lat)
-    tri_x1, tri_y1 = projection(
-        meshes[mesh_idx].lon1[tri_idx], meshes[mesh_idx].lat1[tri_idx]
+    block = get_tde_displacement_slab_single_mesh(
+        obs_lon,
+        obs_lat,
+        meshes,
+        material_lambda,
+        material_mu,
+        mesh_idx=mesh_idx,
+        tri_start=tri_idx,
+        tri_stop=tri_idx + 1,
     )
-    tri_x2, tri_y2 = projection(
-        meshes[mesh_idx].lon2[tri_idx], meshes[mesh_idx].lat2[tri_idx]
-    )
-    tri_x3, tri_y3 = projection(
-        meshes[mesh_idx].lon3[tri_idx], meshes[mesh_idx].lat3[tri_idx]
-    )
-    tri_z1 = KM2M * meshes[mesh_idx].dep1[tri_idx]
-    tri_z2 = KM2M * meshes[mesh_idx].dep2[tri_idx]
-    tri_z3 = KM2M * meshes[mesh_idx].dep3[tri_idx]
-
-    # Package coordinates for cutde call
-    obs_coords = np.vstack((obs_x, obs_y, np.zeros_like(obs_x))).T
-    tri_coords = np.array(
-        [[tri_x1, tri_y1, tri_z1], [tri_x2, tri_y2, tri_z2], [tri_x3, tri_y3, tri_z3]]
-    )
-
-    # Call cutde, multiply by displacements, and package for the return
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        disp_mat = cutde_halfspace.disp_matrix(
-            obs_pts=obs_coords, tris=np.array([tri_coords]), nu=poissons_ratio
-        )
-    slip = np.array([[strike_slip, dip_slip, tensile_slip]])
-    disp = disp_mat.reshape((-1, 3)).dot(slip.flatten())
+    slip = np.array([strike_slip, dip_slip, tensile_slip], dtype=np.float64)
+    disp = block @ slip
     vel_east = disp[0::3]
     vel_north = disp[1::3]
     vel_up = disp[2::3]
     return vel_east, vel_north, vel_up
+
+
+def get_tde_displacement_slab_single_mesh(
+    obs_lon,
+    obs_lat,
+    meshes,
+    material_lambda,
+    material_mu,
+    mesh_idx,
+    tri_start,
+    tri_stop,
+    out=None,
+):
+    """Dense displacement columns for triangles [tri_start, tri_stop) of one mesh.
+
+    Returns a (3 * n_obs, 3 * (tri_stop - tri_start)) float64 array. For local
+    triangle j = t - tri_start, column 3*j is the response to unit strike-slip,
+    3*j + 1 to unit dip-slip, and 3*j + 2 to unit tensile slip. Rows interleave
+    (east, north, up) per observation point, matching the layout documented in
+    get_tde_to_velocities_single_mesh.
+
+    Each triangle is evaluated with a single cutde disp_matrix call that yields
+    all three slip components at once. If out is given, the columns are written
+    into it (it must have shape (3 * n_obs, 3 * (tri_stop - tri_start))) and it
+    is returned.
+    """
+    poissons_ratio = material_mu / (2 * (material_mu + material_lambda))
+    mesh = meshes[mesh_idx]
+    obs_lon = np.asarray(obs_lon)
+    obs_lat = np.asarray(obs_lat)
+    n_obs = obs_lon.size
+    if out is None:
+        out = np.empty((3 * n_obs, 3 * (tri_stop - tri_start)))
+    else:
+        assert out.shape == (3 * n_obs, 3 * (tri_stop - tri_start))
+
+    for j, t in enumerate(range(tri_start, tri_stop)):
+        # Project coordinates into a plane locally tangent at the triangle centroid
+        projection = get_transverse_projection(
+            mesh.centroids[t, 0], mesh.centroids[t, 1]
+        )
+        obs_x, obs_y = projection(obs_lon, obs_lat)
+        tri_x1, tri_y1 = projection(mesh.lon1[t], mesh.lat1[t])
+        tri_x2, tri_y2 = projection(mesh.lon2[t], mesh.lat2[t])
+        tri_x3, tri_y3 = projection(mesh.lon3[t], mesh.lat3[t])
+        tri_z1 = KM2M * mesh.dep1[t]
+        tri_z2 = KM2M * mesh.dep2[t]
+        tri_z3 = KM2M * mesh.dep3[t]
+
+        # Package coordinates for cutde call
+        obs_coords = np.vstack((obs_x, obs_y, np.zeros_like(obs_x))).T
+        tri_coords = np.array(
+            [
+                [tri_x1, tri_y1, tri_z1],
+                [tri_x2, tri_y2, tri_z2],
+                [tri_x3, tri_y3, tri_z3],
+            ]
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            disp_mat = cutde_halfspace.disp_matrix(
+                obs_pts=obs_coords, tris=np.array([tri_coords]), nu=poissons_ratio
+            )
+        # disp_mat has shape (n_obs, 3 displacement components, 1, 3 slip
+        # components); the reshape gives rows interleaved (east, north, up) per
+        # observation point and columns (strike-slip, dip-slip, tensile slip)
+        out[:, 3 * j : 3 * j + 3] = disp_mat.reshape(3 * n_obs, 3)
+    return out
 
 
 def get_tri_smoothing_matrix_simple(share, n_dim) -> csr_matrix:

--- a/scripts/bench_eigen_memory.py
+++ b/scripts/bench_eigen_memory.py
@@ -1,0 +1,128 @@
+"""Peak-memory benchmark: dense vs batched eigen_to_velocities (issue #485).
+
+Compares the pre-#485 computation (materialize the full (3 * n_stations,
+3 * n_tris) TDE matrix, fancy-index copy, one matmul) against the streaming
+triangle-chunk accumulation, on the wna test mesh with synthetically inflated
+station counts.
+
+Each variant runs in its own subprocess because ru_maxrss is a process-lifetime
+high-water mark. The checksums of both variants must agree to ~1e-6 relative.
+
+Usage:
+    pixi run python scripts/bench_eigen_memory.py                # both variants
+    pixi run python scripts/bench_eigen_memory.py --n-stations 25000
+    pixi run python scripts/bench_eigen_memory.py --variant dense
+"""
+
+import argparse
+import resource
+import subprocess
+import sys
+import time
+import tracemalloc
+
+import numpy as np
+
+CONFIG = "tests/configs/test_wna_config.json"
+
+
+def synthetic_stations(model, n_stations, seed=0):
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(0, len(model.station), n_stations)
+    station = model.station.iloc[idx].reset_index(drop=True).copy()
+    station["lon"] += rng.uniform(-0.05, 0.05, n_stations)
+    station["lat"] += rng.uniform(-0.05, 0.05, n_stations)
+    return station
+
+
+def run_variant(variant, n_stations, budget_gb):
+    import celeri
+    from celeri.celeri_util import get_keep_index_12
+    from celeri.operators import (
+        _accumulate_eigen_to_velocities_streaming,
+        _OperatorBuilder,
+        _project_tde_rows_to_eigen,
+        _store_eigenvectors_to_tde_slip,
+    )
+    from celeri.spatial import get_tde_to_velocities_single_mesh
+
+    config = celeri.get_config(CONFIG)
+    config.elastic_operator_cache_dir = None
+    config.tde_operator_memory_gb = budget_gb
+    model = celeri.build_model(config)
+    station = synthetic_stations(model, n_stations)
+
+    builder = _OperatorBuilder(model)
+    _store_eigenvectors_to_tde_slip(model, builder)
+    eigenvectors = builder.eigenvectors_to_tde_slip[0]
+    n_tris = model.meshes[0].lon1.size
+    dense_gb = (3 * n_stations) * (3 * n_tris) * 8 / 2**30
+
+    start = time.perf_counter()
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    if variant == "dense":
+        tde = get_tde_to_velocities_single_mesh(model.meshes, station, config, 0)
+        result = -tde[:, get_keep_index_12(tde.shape[1])] @ eigenvectors
+    elif variant == "batched":
+        result = _accumulate_eigen_to_velocities_streaming(
+            model.meshes,
+            station,
+            config,
+            0,
+            eigenvectors,
+            target_bytes=int(budget_gb * 2**30),
+        )
+    elif variant == "rowbatched":
+        # The non-streaming/cache-read projection path, fed by a dense matrix
+        tde = get_tde_to_velocities_single_mesh(model.meshes, station, config, 0)
+        result = _project_tde_rows_to_eigen(tde, eigenvectors, int(budget_gb * 2**30))
+    else:
+        raise ValueError(variant)
+    _, tm_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    elapsed = time.perf_counter() - start
+
+    ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform != "darwin":
+        ru_maxrss *= 1024  # linux reports KiB, macOS reports bytes
+    print(
+        f"{variant:>10s}  n_stations={n_stations}  n_tris={n_tris}  "
+        f"dense_equiv={dense_gb:6.2f} GiB  "
+        f"tracemalloc_peak={tm_peak / 2**30:6.2f} GiB  "
+        f"ru_maxrss={ru_maxrss / 2**30:6.2f} GiB  "
+        f"wall={elapsed:7.1f} s  "
+        f"checksum={result.sum():.17g}",
+        flush=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=["dense", "batched", "rowbatched"])
+    parser.add_argument("--n-stations", type=int, default=25000)
+    parser.add_argument("--budget-gb", type=float, default=0.25)
+    args = parser.parse_args()
+
+    if args.variant is not None:
+        run_variant(args.variant, args.n_stations, args.budget_gb)
+        return
+
+    for variant in ("dense", "batched"):
+        subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--variant",
+                variant,
+                "--n-stations",
+                str(args.n_stations),
+                "--budget-gb",
+                str(args.budget_gb),
+            ],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_batched_eigen.py
+++ b/tests/test_batched_eigen.py
@@ -1,0 +1,458 @@
+"""Tests for the batched/streaming eigen operator construction (issue #485).
+
+The streaming MCMC path (mcmc_station_velocity_method="project_to_eigen") no
+longer materializes the dense per-mesh (3 * n_stations, 3 * n_tris) TDE matrix.
+These tests pin:
+  1. Bitwise equality of the single-disp_matrix-call slab helper against the
+     pre-#485 one-hot construction (reimplemented inline here).
+  2. Numerical equivalence of the triangle-chunk accumulation and the row-batch
+     projection against the dense reference, across batch-size edge cases.
+  3. Cache behavior: legacy full-matrix caches are still read (in row slabs),
+     and streaming mode no longer writes TDE datasets.
+  4. A tracemalloc guard that the streaming path stays far below the dense
+     matrix footprint.
+
+All equivalence tests reuse a single model per module scope so that
+mesh.eigenvectors are held fixed: eigenvector signs are arbitrary if recomputed
+(scipy eigh/eigsh do no sign normalization), so results from two independent
+build_model calls must never be compared.
+"""
+
+import warnings
+
+import cutde.halfspace as cutde_halfspace
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+import celeri
+from celeri.celeri_util import get_keep_index_12, get_transverse_projection
+from celeri.constants import KM2M
+from celeri.operators import (
+    _accumulate_eigen_to_velocities_streaming,
+    _hash_elastic_operator_input,
+    _OperatorBuilder,
+    _project_operator_to_los,
+    _project_tde_rows_to_eigen,
+    _store_eigenvectors_to_tde_slip,
+    build_los_operators,
+    build_operators,
+)
+from celeri.spatial import (
+    get_tde_displacement_slab_single_mesh,
+    get_tde_to_velocities_single_mesh,
+)
+
+WNA_CONFIG = "tests/configs/test_wna_config.json"
+
+
+def _station_subset(config, n_stations):
+    """First n stations that survive processing (process_station drops flag == 0)."""
+    station = pd.read_csv(config.station_file_name)
+    return station[station.flag != 0].iloc[:n_stations].reset_index(drop=True)
+
+
+def _wna_model(n_stations, cache_dir=None, **build_kwargs):
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = cache_dir
+    station = _station_subset(config, n_stations)
+    return celeri.build_model(config, override_station=station, **build_kwargs)
+
+
+def _eigenvectors_to_tde_slip(model):
+    builder = _OperatorBuilder(model)
+    _store_eigenvectors_to_tde_slip(model, builder)
+    return builder.eigenvectors_to_tde_slip
+
+
+@pytest.fixture(scope="module")
+def wna_model():
+    """60-station wna model (1 mesh, 1841 triangles)."""
+    return _wna_model(60)
+
+
+@pytest.fixture(scope="module")
+def wna_eigenvectors(wna_model):
+    return _eigenvectors_to_tde_slip(wna_model)[0]
+
+
+@pytest.fixture(scope="module")
+def wna_dense(wna_model):
+    """The dense per-mesh TDE matrix (the object streaming mode avoids)."""
+    return get_tde_to_velocities_single_mesh(
+        wna_model.meshes, wna_model.station, wna_model.config, mesh_idx=0
+    )
+
+
+@pytest.fixture(scope="module")
+def wna_reference(wna_dense, wna_eigenvectors):
+    """The exact pre-#485 projection: fancy-index copy then one big matmul."""
+    keep = get_keep_index_12(wna_dense.shape[1])
+    return -wna_dense[:, keep] @ wna_eigenvectors
+
+
+def _one_hot_column_reference(model, tri_idx, slip):
+    """Pre-#485 per-triangle computation: a full disp_matrix call dotted with a
+    one-hot slip vector (this is what get_tri_displacements_single_mesh did
+    before the refactor). Returns the (3 * n_obs,) interleaved displacement
+    vector.
+    """
+    mesh = model.meshes[0]
+    config = model.config
+    poissons_ratio = config.material_mu / (
+        2 * (config.material_mu + config.material_lambda)
+    )
+    projection = get_transverse_projection(
+        mesh.centroids[tri_idx, 0], mesh.centroids[tri_idx, 1]
+    )
+    obs_lon = model.station.lon.to_numpy()
+    obs_lat = model.station.lat.to_numpy()
+    obs_x, obs_y = projection(obs_lon, obs_lat)
+    tri_x1, tri_y1 = projection(mesh.lon1[tri_idx], mesh.lat1[tri_idx])
+    tri_x2, tri_y2 = projection(mesh.lon2[tri_idx], mesh.lat2[tri_idx])
+    tri_x3, tri_y3 = projection(mesh.lon3[tri_idx], mesh.lat3[tri_idx])
+    tri_coords = np.array(
+        [
+            [tri_x1, tri_y1, KM2M * mesh.dep1[tri_idx]],
+            [tri_x2, tri_y2, KM2M * mesh.dep2[tri_idx]],
+            [tri_x3, tri_y3, KM2M * mesh.dep3[tri_idx]],
+        ]
+    )
+    obs_coords = np.vstack((obs_x, obs_y, np.zeros_like(obs_x))).T
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        disp_mat = cutde_halfspace.disp_matrix(
+            obs_pts=obs_coords, tris=np.array([tri_coords]), nu=poissons_ratio
+        )
+    return disp_mat.reshape((-1, 3)).dot(np.array(slip))
+
+
+def test_slab_helper_bitwise_equals_one_hot_path(wna_model):
+    """The single-call slab must reproduce the pre-#485 one-hot construction
+    bitwise (extracting a column of the Green's tensor equals dotting with a
+    one-hot slip vector exactly, since x*1 + y*0 + z*0 is exact for finite
+    floats).
+    """
+    n_tris = wna_model.meshes[0].lon1.size
+    config = wna_model.config
+    for tri_idx in [0, 17, n_tris - 1]:
+        slab = get_tde_displacement_slab_single_mesh(
+            wna_model.station.lon.to_numpy(),
+            wna_model.station.lat.to_numpy(),
+            wna_model.meshes,
+            config.material_lambda,
+            config.material_mu,
+            mesh_idx=0,
+            tri_start=tri_idx,
+            tri_stop=tri_idx + 1,
+        )
+        for col, slip in enumerate([(1, 0, 0), (0, 1, 0), (0, 0, 1)]):
+            expected = _one_hot_column_reference(wna_model, tri_idx, slip)
+            assert np.array_equal(slab[:, col], expected)
+
+
+@pytest.mark.parametrize("tri_batch", [1, 3, 7, "n_tris", "oversize"])
+def test_accumulation_matches_dense_reference(
+    wna_model, wna_eigenvectors, wna_reference, tri_batch
+):
+    """Triangle-chunk accumulation must match the dense projection for batch
+    sizes covering the degenerate, non-divisor, exact, and oversize cases.
+    """
+    n_tris = wna_model.meshes[0].lon1.size
+    batch = {"n_tris": n_tris, "oversize": n_tris + 13}.get(tri_batch, tri_batch)
+    result = _accumulate_eigen_to_velocities_streaming(
+        wna_model.meshes,
+        wna_model.station,
+        wna_model.config,
+        0,
+        wna_eigenvectors,
+        target_bytes=2**30,
+        tri_batch_size=batch,
+    )
+    # Full 3 * n_stations rows are kept (the docstring used to claim 2 *
+    # n_stations; consumers index rows via station_row_keep_index)
+    assert result.shape == (3 * len(wna_model.station), wna_eigenvectors.shape[1])
+    np.testing.assert_allclose(result, wna_reference, rtol=1e-6, atol=1e-9)
+
+
+def test_default_batch_size_derivation(wna_model, wna_eigenvectors, wna_reference):
+    """Batch size derived from a small memory budget (forces several chunks)."""
+    n_obs = len(wna_model.station)
+    # Budget for ~11 triangles per chunk
+    result = _accumulate_eigen_to_velocities_streaming(
+        wna_model.meshes,
+        wna_model.station,
+        wna_model.config,
+        0,
+        wna_eigenvectors,
+        target_bytes=11 * 72 * n_obs,
+    )
+    np.testing.assert_allclose(result, wna_reference, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.parametrize("rows_per_batch", [1, 7, 10**9])
+def test_row_projection_matches_dense_reference(
+    wna_dense, wna_eigenvectors, wna_reference, rows_per_batch
+):
+    """Row-batched projection (cache-read / non-streaming path) must match the
+    dense fancy-index projection for degenerate, non-divisor, and single-batch
+    row-slab sizes.
+    """
+    target_bytes = rows_per_batch * 8 * wna_dense.shape[1]
+    result = _project_tde_rows_to_eigen(wna_dense, wna_eigenvectors, target_bytes)
+    np.testing.assert_allclose(result, wna_reference, rtol=1e-12, atol=1e-12)
+
+
+@pytest.fixture(scope="module")
+def japan_model():
+    """3-mesh japan model with a small station subset (multi-mesh loop)."""
+    config = celeri.get_config("tests/configs/test_japan_config.json")
+    config.elastic_operator_cache_dir = None
+    station = _station_subset(config, 25)
+    return celeri.build_model(config, override_station=station)
+
+
+@pytest.mark.parametrize("mesh_idx", [0, 1, 2])
+def test_accumulation_matches_dense_reference_multimesh(japan_model, mesh_idx):
+    """Multi-mesh model: catches per-mesh index bugs; batch 7 does not divide
+    any of the three triangle counts.
+    """
+    eigenvectors = _eigenvectors_to_tde_slip(japan_model)[mesh_idx]
+    dense = get_tde_to_velocities_single_mesh(
+        japan_model.meshes, japan_model.station, japan_model.config, mesh_idx=mesh_idx
+    )
+    assert dense.ndim == 2
+    reference = -dense[:, get_keep_index_12(dense.shape[1])] @ eigenvectors
+    result = _accumulate_eigen_to_velocities_streaming(
+        japan_model.meshes,
+        japan_model.station,
+        japan_model.config,
+        mesh_idx,
+        eigenvectors,
+        target_bytes=2**30,
+        tri_batch_size=7,
+    )
+    np.testing.assert_allclose(result, reference, rtol=1e-6, atol=1e-9)
+
+
+def test_streaming_build_matches_dense_build(tmp_path):
+    """End-to-end build_operators with and without discard_tde_to_velocities on
+    one shared model. The dense build writes the full TDE cache; the streaming
+    build then reads it in row slabs.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops_dense = build_operators(
+        model, eigen=True, tde=True, discard_tde_to_velocities=False
+    )
+    ops_stream = build_operators(
+        model, eigen=True, tde=True, discard_tde_to_velocities=True
+    )
+    assert ops_stream.tde is not None and ops_stream.tde.tde_to_velocities is None
+    assert ops_dense.eigen is not None and ops_stream.eigen is not None
+    for i in ops_dense.eigen.eigen_to_velocities:
+        np.testing.assert_allclose(
+            ops_stream.eigen.eigen_to_velocities[i],
+            ops_dense.eigen.eigen_to_velocities[i],
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+
+def test_streaming_reads_legacy_full_tde_cache(tmp_path):
+    """Format compatibility: a full dense tde_to_velocities_<i> dataset written
+    by pre-#485 code must still be consumed by the streaming path. The cached
+    matrix is scaled by 2 so the test proves the cache (not a recompute) was
+    the source of the result.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    dense = get_tde_to_velocities_single_mesh(
+        model.meshes, model.station, model.config, mesh_idx=0
+    )
+    assert dense.ndim == 2
+    # Let _store_elastic_operators establish the cache file first (it would
+    # rebuild a file it does not recognize), then inject the legacy dataset
+    build_operators(model, eigen=True, tde=True, discard_tde_to_velocities=True)
+    input_hash = _hash_elastic_operator_input(
+        [mesh.config for mesh in model.meshes], model.station, model.config
+    )
+    with h5py.File(tmp_path / f"{input_hash}.hdf5", "a") as hdf5_file:
+        hdf5_file.create_dataset("tde_to_velocities_0", data=2.0 * dense)
+
+    ops = build_operators(model, eigen=True, tde=True, discard_tde_to_velocities=True)
+    assert ops.eigen is not None
+    expected = (
+        -2.0
+        * dense[:, get_keep_index_12(dense.shape[1])]
+        @ ops.eigen.eigenvectors_to_tde_slip[0]
+    )
+    np.testing.assert_allclose(
+        ops.eigen.eigen_to_velocities[0], expected, rtol=1e-10, atol=1e-10
+    )
+
+
+def test_streaming_does_not_write_tde_cache(tmp_path):
+    """Streaming mode must no longer persist dense TDE matrices (at production
+    scale they would be hundreds of gigabytes on disk).
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    build_operators(model, eigen=True, tde=True, discard_tde_to_velocities=True)
+    input_hash = _hash_elastic_operator_input(
+        [mesh.config for mesh in model.meshes], model.station, model.config
+    )
+    cache_file = tmp_path / f"{input_hash}.hdf5"
+    assert cache_file.exists(), "streaming build should still cache okada operators"
+    with h5py.File(cache_file, "r") as hdf5_file:
+        tde_keys = [k for k in hdf5_file if k.startswith("tde_to_velocities_")]
+    assert tde_keys == []
+
+
+def test_dense_build_after_streaming_cache(tmp_path):
+    """A streaming run leaves a cache with okada but no TDE datasets. A later
+    non-streaming build with the same cache (e.g. Operators.from_disk after a
+    save_operators=False run) must compute the missing TDE matrices instead of
+    returning empty operators, and must write them back to the cache.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    build_operators(model, eigen=True, tde=True, discard_tde_to_velocities=True)
+
+    ops_dense = build_operators(
+        model, eigen=True, tde=True, discard_tde_to_velocities=False
+    )
+    assert ops_dense.tde is not None and ops_dense.tde.tde_to_velocities is not None
+    dense = ops_dense.tde.tde_to_velocities[0]
+    reference = get_tde_to_velocities_single_mesh(
+        model.meshes, model.station, model.config, mesh_idx=0
+    )
+    np.testing.assert_allclose(dense, reference, rtol=1e-10, atol=1e-10)
+
+    input_hash = _hash_elastic_operator_input(
+        [mesh.config for mesh in model.meshes], model.station, model.config
+    )
+    with h5py.File(tmp_path / f"{input_hash}.hdf5", "r") as hdf5_file:
+        assert "tde_to_velocities_0" in hdf5_file
+
+
+def test_segment_edit_streaming_preserves_tde_cache(tmp_path):
+    """A streaming run after a segment edit rewrites the okada part of the
+    cache but must NOT destroy previously cached TDE datasets (they stay valid:
+    the cache hash covers stations, meshes, and materials, not segments).
+    """
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = tmp_path
+    station = _station_subset(config, 25)
+    model = celeri.build_model(config, override_station=station)
+    # Dense build populates the cache with tde_to_velocities datasets
+    build_operators(model, eigen=True, tde=True, discard_tde_to_velocities=False)
+
+    # Edit one segment (locking depth change alters the okada operator only)
+    segment = model.segment.copy(deep=True)
+    segment.loc[0, "locking_depth"] = float(segment.loc[0, "locking_depth"]) + 1.0
+    model_edited = celeri.build_model(
+        config, override_station=station, override_segment=segment
+    )
+    build_operators(model_edited, eigen=True, tde=True, discard_tde_to_velocities=True)
+
+    input_hash = _hash_elastic_operator_input(
+        [mesh.config for mesh in model_edited.meshes],
+        model_edited.station,
+        model_edited.config,
+    )
+    with h5py.File(tmp_path / f"{input_hash}.hdf5", "r") as hdf5_file:
+        assert "tde_to_velocities_0" in hdf5_file, (
+            "segment edit during streaming must not destroy cached TDE datasets"
+        )
+
+
+def test_streaming_peak_memory_stays_below_dense():
+    """Regression guard: with a small memory budget, the streaming projection
+    must never come close to materializing the dense TDE matrix.
+    """
+    import tracemalloc
+
+    model = _wna_model(400)
+    eigenvectors = _eigenvectors_to_tde_slip(model)[0]
+    n_stations = len(model.station)
+    n_tris = model.meshes[0].lon1.size
+    dense_bytes = (3 * n_stations) * (3 * n_tris) * 8
+    target_bytes = 4 * 2**20  # 4 MiB slab budget
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    result = _accumulate_eigen_to_velocities_streaming(
+        model.meshes, model.station, model.config, 0, eigenvectors, target_bytes
+    )
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert result.shape == (3 * n_stations, eigenvectors.shape[1])
+    assert peak < dense_bytes / 3, (
+        f"streaming peak {peak / 2**20:.0f} MiB vs dense {dense_bytes / 2**20:.0f} MiB"
+    )
+
+
+def _synthetic_los(station, n_los=12, seed=7):
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(0, len(station), n_los)
+    look = rng.normal(size=(n_los, 3))
+    look /= np.linalg.norm(look, axis=1, keepdims=True)
+    return pd.DataFrame(
+        {
+            "lon": station.lon.to_numpy()[idx] + rng.uniform(-0.1, 0.1, n_los),
+            "lat": station.lat.to_numpy()[idx] + rng.uniform(-0.1, 0.1, n_los),
+            "los_val": rng.normal(size=n_los),
+            "look_vector_east": look[:, 0],
+            "look_vector_north": look[:, 1],
+            "look_vector_up": look[:, 2],
+        }
+    )
+
+
+def test_eigen_to_los_batched_matches_dense_reference():
+    """The LOS path mirrors the station path: chunked accumulation (discard) and
+    row-batched projection (keep) must both match the dense reference.
+    """
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = None
+    station = pd.read_csv(config.station_file_name).iloc[:25].reset_index(drop=True)
+    model = celeri.build_model(config, override_station=station)
+    los = _synthetic_los(model.station)
+    model = celeri.build_model(config, override_station=station, override_los=los)
+
+    ops = build_operators(model, eigen=True, tde=True)
+    assert ops.eigen is not None
+    assert model.los is not None
+
+    # Dense reference computed the pre-#485 way
+    tde = get_tde_to_velocities_single_mesh(
+        model.meshes, model.los, model.config, mesh_idx=0
+    )
+    look_vectors = np.column_stack(
+        [
+            model.los.look_vector_east.to_numpy(),
+            model.los.look_vector_north.to_numpy(),
+            model.los.look_vector_up.to_numpy(),
+        ]
+    )
+    tde_los = _project_operator_to_los(tde, look_vectors)
+    reference = (
+        -tde_los[:, get_keep_index_12(tde_los.shape[1])]
+        @ ops.eigen.eigenvectors_to_tde_slip[0]
+    )
+
+    # Force several triangle chunks in the discard path
+    model.config.tde_operator_memory_gb = (100 * 72 * len(model.los)) / 2**30
+
+    los_discard = build_los_operators(model, ops, discard_tde_to_los=True)
+    los_keep = build_los_operators(model, ops, discard_tde_to_los=False)
+    assert los_discard is not None and los_keep is not None
+
+    assert los_discard.tde_to_los is None
+    np.testing.assert_allclose(
+        los_discard.eigen_to_los[0], reference, rtol=1e-9, atol=1e-9
+    )
+    np.testing.assert_allclose(
+        los_keep.eigen_to_los[0], reference, rtol=1e-9, atol=1e-9
+    )
+    assert los_keep.tde_to_los is not None
+    np.testing.assert_allclose(los_keep.tde_to_los[0], tde_los, rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
Fixes #485

## Problem

With `mcmc_station_velocity_method="project_to_eigen"`, `_compute_eigen_to_velocities` materialized, per mesh, the full dense `(3·n_stations, 3·n_tris)` TDE operator plus fancy-index copies, just to reduce it to a tiny `(3·n_stations, n_modes)` product. Measurement on the 100k-station WNA model showed the old expression `-tde[:, keep] @ E` actually holds **three** giants simultaneously (dense matrix + kept-column copy + a negated copy from the unary minus): 78.7 GiB for the largest mesh alone, worse than the estimate in #485.

## What changed

- **`spatial.py`**: new `get_tde_displacement_slab_single_mesh` computes the `(3·n_obs, 3)` strike/dip/tensile column-triple for a range of triangles with **one** `cutde.disp_matrix` call per triangle. The previous code called `disp_matrix` three times per triangle with one-hot slip vectors, discarding 2/3 of each result — the refactored assemblers are bitwise-identical and ~3× faster. **Tensile columns are still computed in every slab** (they come for free from `disp_matrix`); only the eigen projection skips them, as before.
- **`operators.py`**: `_compute_eigen_to_velocities` never builds the dense matrix:
  - cache miss → accumulate `-slab[:, keep] @ E[2·t0:2·t1]` over triangle chunks;
  - cache hit → project contiguous row slabs read directly from the HDF5 dataset;
  - non-streaming → row-batched projection over the in-memory matrix (no more giant fancy-index copy).
- **LOS path** gets the same treatment; streaming mode never holds a mesh's full `tde_to_los`.
- **`config.py`**: new `tde_operator_memory_gb: float = 1.0` slab memory budget (peak transient ≈ 1.7× this value).
- **Cache policy**: streaming runs no longer write dense TDE matrices to the elastic-operator cache (~970 GB for the 100k model). Legacy caches are still read, slab-wise. Two adjacent latent bugs fixed:
  - a non-streaming build against a streaming-created cache (e.g. `save_operators=False` → `Operators.from_disk`) now computes the missing TDE matrices instead of returning empty operators and crashing;
  - cache rewrites triggered while streaming (segment edit, `force_recompute`) preserve existing `tde_to_velocities_*` datasets instead of destroying them.

## Measured results (100,592 stations, 186 meshes, 133,945 triangles)

Largest mesh (segmesh37, 4,674 tris), identical eigenvectors both runs:

| | before | after |
|---|---|---|
| peak RSS | 78.7 GiB | **19.4 GiB** (~1.6 GiB operator transients) |
| wall time | 394 s | **132 s** |
| max abs difference | — | 2×10⁻¹⁶ |

Full streaming operator construction (exactly what `celeri-solve --solve_type mcmc` runs before nutpie compilation): completes in **76.6 min at 47.2 GiB peak** with a flat memory profile — vs ~120 GiB estimated for the old code (marginal on a 128 GB machine, impossible at 250k stations). Remaining peak is entirely the Okada operator (~29 GiB) and the resident eigen dict (11.1 GiB) — follow-ups below.

## Testing

- `tests/test_solve_dense.py --arraydiff`: all 31 golden baselines pass **unchanged** (the dense assembly is bitwise-identical; verified directly against the pre-change code).
- New `tests/test_batched_eigen.py` (21 tests): bitwise slab-vs-one-hot guard; chunked-vs-dense equivalence across batch sizes {1, 3, 7, exact, oversize} on single- and multi-mesh models; streaming-vs-dense `build_operators`; legacy cache-format read (with a scaled-cache probe proving the cache was the source); no-TDE-cache-write policy; cache preservation across segment edits; dense-build-after-streaming-cache regression; tracemalloc peak-memory guard; LOS equivalence.
- New `scripts/bench_eigen_memory.py` peak-memory benchmark (subprocess-isolated ru_maxrss + tracemalloc).
- optimize, mcmc/other, and legacy-mcmc suites all pass.

## Follow-ups (not in this PR)

- The Okada segment operator `(3·n_stations, 3·n_segments)` (~29 GiB at 100k) is now the memory ceiling; every runtime consumer uses only the composed `okada @ rotation_to_slip_rate` product, so the same streaming treatment applies — issue to follow.
- The resident `eigen_to_velocities` dict (~11 GiB at 100k) is held twice during MCMC (float64 dict + float32 constants baked into the compiled graph).
- #69 (ACA/low-rank assembly) remains the structural long-term answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)