### PR TITLE
Never hold the dense Okada segment operator in memory

### DIFF
--- a/celeri/__init__.py
+++ b/celeri/__init__.py
@@ -40,7 +40,6 @@ from celeri.operators import (
     get_rotation_to_slip_rate_partials,
     get_rotation_to_tri_slip_rate_partials,
     get_rotation_to_velocities_partials,
-    get_segment_station_operator_okada,
     get_slip_rate_bounds,
     get_slip_rate_constraints,
     get_tde_to_velocities_single_mesh,
@@ -89,7 +88,9 @@ from celeri.solve import (
 )
 from celeri.solve_mcmc import solve_mcmc
 from celeri.spatial import (
+    get_okada_displacement_slab,
     get_okada_displacements,
+    get_segment_station_operator_okada,
     get_shared_sides,
     get_tde_to_velocities,
     get_tri_displacements,
@@ -127,6 +128,7 @@ __all__ = [
     "get_logger",
     "get_mogi_to_velocities_partials",
     "get_newest_run_folder",
+    "get_okada_displacement_slab",
     "get_okada_displacements",
     "get_qp_all_inequality_operator_and_data_vector",
     "get_qp_slip_rate_inequality_operator_and_data_vector",

--- a/celeri/operators.py
+++ b/celeri/operators.py
@@ -28,7 +28,7 @@ import hashlib
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Any, overload
+from typing import overload
 
 import h5py
 import numpy as np
@@ -67,9 +67,10 @@ from celeri.spatial import (
     get_block_strain_rate_to_velocities_partials,
     get_global_float_block_rotation_partials,
     get_mogi_to_velocities_partials,
+    get_okada_displacement_slab,
     get_rotation_to_slip_rate_partials,
     get_rotation_to_velocities_partials,
-    get_segment_station_operator_okada,
+    get_segment_station_operator_okada,  # noqa: F401  (re-exported for backward compatibility)
     get_tde_displacement_slab_single_mesh,
     get_tde_to_velocities_single_mesh,
     get_tri_smoothing_matrix,
@@ -409,10 +410,6 @@ class LosOperators:
     """Maps Mogi sources to LOS velocities; shape (n_los, n_mogis).
 
     UNITS: [dimensionless] - maps Mogi parameters → [mm/yr] LOS velocity."""
-    okada_to_los: np.ndarray
-    """Maps segment slip rates to LOS velocities via Okada; shape (n_los, 3 * n_segments).
-
-    UNITS: [dimensionless] - maps slip rates [mm/yr] → [mm/yr] LOS velocity."""
     rotation_to_okada_los: np.ndarray
     """Composed operator rotation -> slip rate -> Okada -> LOS; shape (n_los, 3 * n_blocks).
 
@@ -431,6 +428,14 @@ class LosOperators:
     Can be None if discarded after building eigen_to_los to save memory.
 
     UNITS: [dimensionless] - maps TDE slip rates [mm/yr] → [mm/yr] LOS velocity."""
+    okada_to_los: np.ndarray | None = None
+    """Maps segment slip rates to LOS velocities via Okada; shape (n_los, 3 * n_segments).
+
+    UNITS: [dimensionless] - maps slip rates [mm/yr] → [mm/yr] LOS velocity.
+
+    No longer built (always None): only the composed rotation_to_okada_los is
+    consumed anywhere, so the dense per-segment LOS operator is never
+    materialized. The field is retained for backward compatibility."""
 
     @property
     def n_los(self) -> int:
@@ -442,13 +447,15 @@ class LosOperators:
         skip = set()
         if self.tde_to_los is None:
             skip.add("tde_to_los")
+        if self.okada_to_los is None:
+            skip.add("okada_to_los")
         dataclass_to_disk(self, path, skip=skip)
 
     @classmethod
     def from_disk(cls, input_dir: str | Path) -> "LosOperators":
         """Load LOS operators from disk."""
         path = Path(input_dir)
-        return dataclass_from_disk(cls, path, skip={"los_err"})
+        return dataclass_from_disk(cls, path, skip={"los_err", "okada_to_los"})
 
 
 @dataclass
@@ -501,15 +508,6 @@ class Operators:
 
     Has shape (3 * n_stations, n_mogis).
     """
-    slip_rate_to_okada_to_velocities: np.ndarray
-    """Okada model slip rate to velocity mapping.
-
-    UNITS: [dimensionless] - Maps slip rates [mm/yr] to velocities [mm/yr].
-    The Okada Green's functions provide the geometric relationship between
-    slip on a fault and surface velocities.
-
-    Has shape (3 * n_stations, 3 * n_segments).
-    """
     rotation_to_tri_slip_rate: dict[int, np.ndarray]
     """Rotation to triangular slip rate mapping.
 
@@ -546,6 +544,21 @@ class Operators:
     """Spherical areas for each block (dimensionless, on unit sphere).
 
     Maps block index to area. Multiply by EARTH_RADIUS^2 to get physical area.
+    """
+    slip_rate_to_okada_to_velocities: np.ndarray | None = None
+    """Okada model slip rate to velocity mapping.
+
+    UNITS: [dimensionless] - Maps slip rates [mm/yr] to velocities [mm/yr].
+    The Okada Green's functions provide the geometric relationship between
+    slip on a fault and surface velocities.
+
+    Has shape (3 * n_stations, 3 * n_segments). Since the streaming refactor
+    this dense matrix is no longer kept in memory (only the composed
+    rotation_to_slip_rate_to_okada_to_velocities is); it lives in the elastic
+    operator cache file when a cache dir is configured. The field is retained
+    (always None) for backward compatibility. To obtain columns, call
+    get_okada_displacement_slab for a segment range or read the
+    "slip_rate_to_okada_to_velocities" dataset from the cache file.
     """
 
     @overload
@@ -667,6 +680,8 @@ class Operators:
             scipy.sparse.save_npz(matrix_path, smoothing_matrix)
 
         skip = {"tde", "eigen", "los", "index", "model", "smoothing_matrix"}
+        if self.slip_rate_to_okada_to_velocities is None:
+            skip.add("slip_rate_to_okada_to_velocities")
 
         dataclass_to_disk(self, path, skip=skip)
 
@@ -741,7 +756,11 @@ class Operators:
             "smoothing_matrix": smoothing_matrix,
         }
 
-        return dataclass_from_disk(cls, path, extra=extra)
+        # Skip the dense okada operator that run folders written by older
+        # versions may contain; it is no longer kept in memory
+        return dataclass_from_disk(
+            cls, path, extra=extra, skip={"slip_rate_to_okada_to_velocities"}
+        )
 
 
 @dataclass
@@ -754,7 +773,6 @@ class _OperatorBuilder:
     rotation_to_slip_rate: np.ndarray | None = None
     block_strain_rate_to_velocities: np.ndarray | None = None
     mogi_to_velocities: np.ndarray | None = None
-    slip_rate_to_okada_to_velocities: np.ndarray | None = None
     eigenvectors_to_tde_slip: dict[int, np.ndarray] = field(default_factory=dict)
     eigenvalues: dict[int, np.ndarray] = field(default_factory=dict)
     rotation_to_tri_slip_rate: dict[int, np.ndarray] = field(default_factory=dict)
@@ -777,7 +795,6 @@ class _OperatorBuilder:
         assert self.rotation_to_slip_rate is not None
         assert self.block_strain_rate_to_velocities is not None
         assert self.mogi_to_velocities is not None
-        assert self.slip_rate_to_okada_to_velocities is not None
         assert self.rotation_to_tri_slip_rate is not None
         assert self.smoothing_matrix is not None
         assert self.tde_slip_rate_constraints is not None
@@ -795,7 +812,6 @@ class _OperatorBuilder:
             rotation_to_slip_rate=self.rotation_to_slip_rate,
             block_strain_rate_to_velocities=self.block_strain_rate_to_velocities,
             mogi_to_velocities=self.mogi_to_velocities,
-            slip_rate_to_okada_to_velocities=self.slip_rate_to_okada_to_velocities,
             rotation_to_tri_slip_rate=self.rotation_to_tri_slip_rate,
             smoothing_matrix=self.smoothing_matrix,
             global_float_block_rotation=self.global_float_block_rotation,
@@ -927,6 +943,12 @@ def build_operators(
 
     operators = _OperatorBuilder(model)
 
+    # Rotation vectors to slip rate operator (needed by the elastic operator
+    # step below to compose the okada operator without materializing it)
+    operators.rotation_to_slip_rate = get_rotation_to_slip_rate_partials(
+        model.segment, model.block
+    )
+
     # Get all elastic operators for segments and TDEs
     # When discard_tde_to_velocities is True, skip loading tde_to_velocities
     # as we'll compute eigen_to_velocities in streaming mode later
@@ -951,11 +973,6 @@ def build_operators(
 
     # Soft slip rate constraints
     operators.slip_rate_constraints = get_slip_rate_constraints(model)
-
-    # Rotation vectors to slip rate operator
-    operators.rotation_to_slip_rate = get_rotation_to_slip_rate_partials(
-        model.segment, model.block
-    )
 
     # Internal block strain rate operator
     (
@@ -989,11 +1006,10 @@ def build_operators(
     # Get rotation to TDE kinematic slip rate operator for all meshes tied to segments
     _store_tde_coupling_constraints(model, operators)
 
-    # Insert block rotations and elastic velocities from fully locked segments
-    assert operators.slip_rate_to_okada_to_velocities is not None
-    operators.rotation_to_slip_rate_to_okada_to_velocities = (
-        operators.slip_rate_to_okada_to_velocities @ operators.rotation_to_slip_rate
-    )
+    # Block rotations and elastic velocities from fully locked segments: the
+    # composed operator was built by _store_elastic_operators without ever
+    # materializing the dense okada matrix
+    assert operators.rotation_to_slip_rate_to_okada_to_velocities is not None
 
     if eigen:
         operators.eigen_to_velocities = _compute_eigen_to_velocities(
@@ -1096,17 +1112,25 @@ def build_los_operators(
     mogi_to_velocities = get_mogi_to_velocities_partials(model.mogi, los, model.config)
     mogi_to_los = _project_operator_to_los(mogi_to_velocities, look_vectors)
 
-    # Segment slip rate to Okada velocity at LOS locations
-    okada_to_velocities = get_segment_station_operator_okada(
-        model.segment, los, model.config
-    )
-    okada_to_los = _project_operator_to_los(okada_to_velocities, look_vectors)
-
-    # Composed rotation -> slip rate -> Okada operator
-    rotation_to_okada_velocities = okada_to_velocities @ operators.rotation_to_slip_rate
-    rotation_to_okada_los = _project_operator_to_los(
-        rotation_to_okada_velocities, look_vectors
-    )
+    # Composed rotation -> slip rate -> Okada -> LOS operator, accumulated per
+    # segment chunk: the dense (3 * n_los, 3 * n_segments) okada operator is
+    # never materialized (raw okada_to_los has no consumers)
+    n_segments = len(model.segment)
+    target_bytes = int(model.config.tde_operator_memory_gb * 2**30)
+    rotation_to_okada_los = np.zeros((n_los, operators.rotation_to_slip_rate.shape[1]))
+    seg_batch_size = _column_triple_batch_size(target_bytes, n_los, n_segments)
+    for s0 in track(
+        range(0, n_segments, seg_batch_size),
+        description="LOS segment elastic        ",
+    ):
+        s1 = min(s0 + seg_batch_size, n_segments)
+        slab = get_okada_displacement_slab(
+            model.segment, los, model.config, seg_start=s0, seg_stop=s1
+        )
+        rotation_to_okada_los += (
+            _project_operator_to_los(slab, look_vectors)
+            @ operators.rotation_to_slip_rate[3 * s0 : 3 * s1, :]
+        )
 
     # TDE operators at LOS locations
     tde_to_los: dict[int, np.ndarray] = {}
@@ -1115,13 +1139,12 @@ def build_los_operators(
     if operators.tde is not None:
         obs_lon = los.lon.to_numpy()
         obs_lat = los.lat.to_numpy()
-        target_bytes = int(model.config.tde_operator_memory_gb * 2**30)
         # When tde_to_los would be discarded anyway, accumulate eigen_to_los
         # per triangle chunk and never hold a mesh's full tde_to_los
         stream_only_eigen = discard_tde_to_los and operators.eigen is not None
         for mesh_idx in range(len(model.meshes)):
             n_tris = model.meshes[mesh_idx].lon1.size
-            tri_batch_size = _tde_tri_batch_size(target_bytes, n_los, n_tris)
+            tri_batch_size = _column_triple_batch_size(target_bytes, n_los, n_tris)
             if stream_only_eigen:
                 assert operators.eigen is not None
                 eigenvectors = operators.eigen.eigenvectors_to_tde_slip[mesh_idx]
@@ -1191,7 +1214,6 @@ def build_los_operators(
         rotation_to_los=rotation_to_los,
         block_strain_rate_to_los=block_strain_rate_to_los,
         mogi_to_los=mogi_to_los,
-        okada_to_los=okada_to_los,
         rotation_to_okada_los=rotation_to_okada_los,
         eigen_to_los=eigen_to_los,
         los_data=los_data,
@@ -1420,49 +1442,127 @@ def _compute_and_cache_tde_to_velocities(
         )
     if cache is not None:
         logger.info("Adding tde_to_velocities to cache")
-        with h5py.File(str(cache), "a") as hdf5_file:
-            for i in range(len(meshes)):
-                key = "tde_to_velocities_" + str(i)
-                if key in hdf5_file:
-                    del hdf5_file[key]
-                hdf5_file.create_dataset(key, data=operators.tde_to_velocities[i])
+        try:
+            with h5py.File(str(cache), "a") as hdf5_file:
+                for i in range(len(meshes)):
+                    key = "tde_to_velocities_" + str(i)
+                    if key in hdf5_file:
+                        del hdf5_file[key]
+                    hdf5_file.create_dataset(key, data=operators.tde_to_velocities[i])
+        except OSError:
+            # Do not lose hours of computation to an unwritable cache file
+            logger.warning(
+                f"Cannot write tde_to_velocities to cache file {cache} "
+                "(locked by a concurrent run?). Continuing without caching."
+            )
 
 
-def _write_elastic_operator_cache(
-    cache: Path,
-    operators: _OperatorBuilder,
-    segment: DataFrame,
-    meshes: list[Mesh],
-    *,
-    write_tde: bool,
-    preserve_existing_tde: bool,
-):
-    """Write the okada operator and segment metadata (and optionally the dense
-    TDE matrices) to the cache file.
+def _open_cache_for_writing(
+    cache: Path, *, preserve_existing: bool
+) -> h5py.File | None:
+    """Open the cache file for writing, tolerating corrupt or locked files.
 
-    When preserve_existing_tde is True the file is updated in place so that
-    tde_to_velocities_<i> datasets written by other (non-streaming) runs
-    survive a rewrite triggered while streaming — those datasets stay valid
-    because the cache hash covers stations, meshes, and material parameters
-    but not segments. HDF5 does not reclaim the space of replaced datasets;
-    use h5repack to compact a cache file if it grows.
+    preserve_existing opens in append mode so that tde_to_velocities_<i>
+    datasets written by other runs survive — they stay valid because the
+    cache hash covers stations, meshes, and material parameters but not
+    segments. Otherwise the file is truncated (HDF5 never reclaims the space
+    of deleted datasets, so append-mode rewrites would grow the file).
+
+    A corrupt/truncated file (e.g. left behind by a killed run) fails to open
+    in append mode and is recreated. A file locked by a concurrent process
+    fails both opens, in which case None is returned and the caller computes
+    without caching.
     """
-    mode = "a" if preserve_existing_tde and cache.exists() else "w"
-    with h5py.File(str(cache), mode) as hdf5_file:
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    mode = "a" if preserve_existing and cache.exists() else "w"
+    try:
+        return h5py.File(str(cache), mode)
+    except OSError:
+        try:
+            return h5py.File(str(cache), "w")
+        except OSError:
+            logger.warning(
+                f"Cannot open cache file {cache} for writing (locked by a "
+                "concurrent run?). Computing without caching."
+            )
+            return None
+
+
+def _compute_okada_composed_and_cache(
+    segment: DataFrame,
+    station: DataFrame,
+    config: Config,
+    rotation_to_slip_rate: np.ndarray,
+    cache: Path | None,
+    target_bytes: int,
+    *,
+    preserve_existing: bool = False,
+) -> np.ndarray:
+    """Build rotation_to_slip_rate_to_okada_to_velocities without ever holding
+    the dense (3 * n_stations, 3 * n_segments) okada operator in memory.
+
+    With a cache configured, the dense operator is written to the cache file
+    slab by slab and the composed product is then streamed back from the
+    completed dataset — the identical code path as a cache hit, so cache-miss
+    and cache-hit results are bitwise equal. Without a cache the composed
+    product is accumulated per segment chunk.
+    """
+    n_segments = len(segment)
+    n_stations = len(station)
+    if n_stations == 0 or n_segments == 0:
+        return np.zeros((3 * n_stations, rotation_to_slip_rate.shape[1]))
+    seg_batch_size = _column_triple_batch_size(target_bytes, n_stations, n_segments)
+    slab_buffer = np.empty((3 * n_stations, 3 * seg_batch_size))
+
+    hdf5_file = None
+    dataset = None
+    if cache is not None:
+        hdf5_file = _open_cache_for_writing(cache, preserve_existing=preserve_existing)
+    if hdf5_file is not None:
         for key in ("slip_rate_to_okada_to_velocities", "segments", "segments_names"):
             if key in hdf5_file:
                 del hdf5_file[key]
-        hdf5_file.create_dataset(
+        # Chunked layout keeps both the column-slab writes here and the later
+        # row-slab reads bounded to whole chunks
+        dataset = hdf5_file.create_dataset(
             "slip_rate_to_okada_to_velocities",
-            data=operators.slip_rate_to_okada_to_velocities,
+            shape=(3 * n_stations, 3 * n_segments),
+            dtype="f8",
+            chunks=True,
         )
-        if write_tde:
-            for i in range(len(meshes)):
-                key = "tde_to_velocities_" + str(i)
-                if key in hdf5_file:
-                    del hdf5_file[key]
-                hdf5_file.create_dataset(key, data=operators.tde_to_velocities[i])
-        _save_segments_to_hdf5(segment, hdf5_file)
+    composed = None
+    if dataset is None:
+        composed = np.zeros((3 * n_stations, rotation_to_slip_rate.shape[1]))
+    try:
+        for s0 in track(
+            range(0, n_segments, seg_batch_size),
+            description="Rectangular segment elastic",
+        ):
+            s1 = min(s0 + seg_batch_size, n_segments)
+            slab = get_okada_displacement_slab(
+                segment,
+                station,
+                config,
+                seg_start=s0,
+                seg_stop=s1,
+                out=slab_buffer[:, : 3 * (s1 - s0)],
+            )
+            if dataset is not None:
+                dataset[:, 3 * s0 : 3 * s1] = slab
+            else:
+                composed += slab @ rotation_to_slip_rate[3 * s0 : 3 * s1, :]
+        if hdf5_file is not None:
+            # Segment metadata is written last so that a crash mid-fill leaves
+            # a cache without metadata, which reads as old-format and triggers
+            # a clean recompute instead of trusting a half-filled dataset
+            _save_segments_to_hdf5(segment, hdf5_file)
+            del slab_buffer
+            composed = _stream_matmul_rows(dataset, rotation_to_slip_rate, target_bytes)
+    finally:
+        if hdf5_file is not None:
+            hdf5_file.close()
+    assert composed is not None
+    return composed
 
 
 def _store_elastic_operators(
@@ -1475,12 +1575,16 @@ def _store_elastic_operators(
     """Calculate (or load previously calculated) elastic operators from
     both fully locked segments and TDE-parameterized surfaces.
 
-    Supports selective recomputation when only some source segment geometries
-    change, in place. If the segment file has changed, rows have been added or removed,
-    or `force_recompute` is True, the operators will be recomputed from scratch.
+    The dense (3 * n_stations, 3 * n_segments) okada operator is never held in
+    memory: only the composed rotation_to_slip_rate_to_okada_to_velocities is
+    produced, either by streaming row slabs from the cached HDF5 dataset or by
+    accumulating segment-chunk slabs as they are computed. The dense operator
+    lives in the cache file (when a cache dir is configured), where selective
+    recomputation updates changed segment columns in place.
 
     Args:
-        operators (_OperatorBuilder): Data structure which the elastic operators will be added to
+        operators (_OperatorBuilder): Data structure which the elastic operators will be added to.
+            rotation_to_slip_rate is built here if not already present.
         model (Model): Model instance
         tde (bool): Whether to compute TDE operators
         skip_tde_to_velocities (bool): If True, skip loading/computing tde_to_velocities.
@@ -1490,6 +1594,14 @@ def _store_elastic_operators(
     meshes = model.meshes
     segment = model.segment
     station = model.station
+
+    if operators.rotation_to_slip_rate is None:
+        # build_operators pre-populates this; standalone/test callers may not
+        operators.rotation_to_slip_rate = get_rotation_to_slip_rate_partials(
+            segment, model.block
+        )
+    rotation_to_slip_rate = operators.rotation_to_slip_rate
+    target_bytes = int(config.tde_operator_memory_gb * 2**30)
 
     cache = None
 
@@ -1512,108 +1624,110 @@ def _store_elastic_operators(
 
         if cache.exists() and not config.force_recompute:
             logger.info(f"Found cached elastic operators at {cache}")
-            hdf5_file = h5py.File(str(cache), "r")
-            cached_operator: np.ndarray[Any, Any] | None = np.array(
-                hdf5_file.get("slip_rate_to_okada_to_velocities")
-            )
-            cached_segments = _load_segments_from_hdf5(hdf5_file)
-            hdf5_file.close()
+            # Read only the small segment metadata for validation; the okada
+            # dataset itself is never loaded whole
+            cached_segments = None
+            okada_dataset_ok = False
+            cache_readable = True
+            try:
+                with h5py.File(str(cache), "r") as hdf5_file:
+                    cached_segments = _load_segments_from_hdf5(hdf5_file)
+                    okada_dataset_ok = (
+                        "slip_rate_to_okada_to_velocities" in hdf5_file
+                        and hdf5_file["slip_rate_to_okada_to_velocities"].shape
+                        == (3 * len(station), 3 * len(segment))
+                    )
+            except OSError:
+                cache_readable = False
+                logger.warning(
+                    "Cache file unreadable (corrupt, truncated, or locked by a "
+                    "concurrent run). Recomputing operators."
+                )
 
-            if cached_segments is None:
+            if not cache_readable:
+                pass
+            elif cached_segments is None or "name" not in cached_segments.columns:
                 logger.info(
                     "Metadata files not found (old cache format). Recomputing operators."
                 )
-                cached_operator = None
+            elif cached_segments["name"].tolist() != segment["name"].tolist():
+                logger.info(
+                    "Segments have been added or removed since last computation. Recomputing operators."
+                )
+            elif not okada_dataset_ok:
+                logger.info(
+                    "Cache missing or mismatched okada operator. Recomputing operators."
+                )
             else:
-                # Check if segments have been added or removed
-                if cached_segments["name"].tolist() != segment["name"].tolist():
-                    logger.info(
-                        "Segments have been added or removed since last computation. Recomputing operators."
-                    )
-                    cached_operator = None
-                elif cached_operator is not None:
-                    changed_segment_indices = _compare_segments(
-                        cached_segments, segment
-                    )
-                    if len(changed_segment_indices) == 0:
-                        logger.info(
-                            "No source geometry changed since last computation. Using cached operator."
-                        )
-                        operators.slip_rate_to_okada_to_velocities = cached_operator
-
-                        if tde and not skip_tde_to_velocities:
-                            hdf5_file = h5py.File(str(cache), "r")
-                            tde_data = hdf5_file.get("tde_to_velocities_0")
-                            if tde_data is not None:
-                                for i in range(len(meshes)):
-                                    operators.tde_to_velocities[i] = np.array(
-                                        hdf5_file.get("tde_to_velocities_" + str(i))
-                                    )
-                                hdf5_file.close()
-                                return
-                            hdf5_file.close()
-                            # Streaming runs cache the okada operator but not
-                            # the dense TDE matrices, so a later non-streaming
-                            # run lands here and must compute them
-                            logger.info(
-                                "Cache missing tde_to_velocities. Computing from scratch."
-                            )
-                            _compute_and_cache_tde_to_velocities(
-                                meshes, station, config, operators, cache
-                            )
-                        return
-
+                changed_segment_indices = _compare_segments(cached_segments, segment)
+                if len(changed_segment_indices) > 0:
                     logger.info(f"Recomputing {len(changed_segment_indices)} segments")
-
-                    operators.slip_rate_to_okada_to_velocities = cached_operator.copy()
-
-                    if len(changed_segment_indices) > 0:
+                    with h5py.File(str(cache), "r+") as hdf5_file:
+                        # Invalidate the segment metadata BEFORE touching the
+                        # dataset: an interrupted update then reads as
+                        # old-format and triggers a clean recompute, instead
+                        # of stale metadata blessing half-updated columns
+                        for key in ("segments", "segments_names"):
+                            if key in hdf5_file:
+                                del hdf5_file[key]
+                        dataset = hdf5_file["slip_rate_to_okada_to_velocities"]
                         for seg_idx in track(
                             changed_segment_indices,
                             description="Recomputing changed segments",
                         ):
-                            single_segment = segment.iloc[
-                                seg_idx : seg_idx + 1
-                            ].reset_index(drop=True)
-                            new_columns = get_segment_station_operator_okada(
-                                single_segment, station, config, progress_bar=False
+                            dataset[:, 3 * seg_idx : 3 * seg_idx + 3] = (
+                                get_okada_displacement_slab(
+                                    segment,
+                                    station,
+                                    config,
+                                    seg_start=seg_idx,
+                                    seg_stop=seg_idx + 1,
+                                )
                             )
-                            col_start = 3 * seg_idx
-                            col_end = col_start + 3
-                            operators.slip_rate_to_okada_to_velocities[
-                                :, col_start:col_end
-                            ] = new_columns
+                        _save_segments_to_hdf5(segment, hdf5_file)
+                else:
+                    logger.info(
+                        "No source geometry changed since last computation. Using cached operator."
+                    )
 
+                # Stream the composed product from the (possibly updated)
+                # dataset in row slabs
+                with h5py.File(str(cache), "r") as hdf5_file:
+                    operators.rotation_to_slip_rate_to_okada_to_velocities = (
+                        _stream_matmul_rows(
+                            hdf5_file["slip_rate_to_okada_to_velocities"],
+                            rotation_to_slip_rate,
+                            target_bytes,
+                        )
+                    )
+
+                if tde and not skip_tde_to_velocities:
                     tde_loaded_from_cache = False
-                    if tde and not skip_tde_to_velocities:
-                        hdf5_file = h5py.File(str(cache), "r")
-                        if hdf5_file.get("tde_to_velocities_0") is not None:
+                    with h5py.File(str(cache), "r") as hdf5_file:
+                        # All per-mesh datasets must be present: a partial set
+                        # (crash during a previous multi-mesh cache write)
+                        # must trigger a recompute, not a half-load
+                        tde_keys_ok = all(
+                            ("tde_to_velocities_" + str(i)) in hdf5_file
+                            for i in range(len(meshes))
+                        )
+                        if tde_keys_ok:
                             for i in range(len(meshes)):
                                 operators.tde_to_velocities[i] = np.array(
                                     hdf5_file.get("tde_to_velocities_" + str(i))
                                 )
                             tde_loaded_from_cache = True
-                        hdf5_file.close()
-                        if not tde_loaded_from_cache:
-                            logger.info(
-                                "Cache missing tde_to_velocities. Computing from scratch."
-                            )
-                            _compute_and_cache_tde_to_velocities(
-                                meshes, station, config, operators, cache=None
-                            )
-
-                    logger.info("Caching updated elastic operators")
-                    cache.parent.mkdir(parents=True, exist_ok=True)
-                    _write_elastic_operator_cache(
-                        cache,
-                        operators,
-                        segment,
-                        meshes,
-                        write_tde=tde and not skip_tde_to_velocities,
-                        preserve_existing_tde=skip_tde_to_velocities,
-                    )
-
-                    return
+                    if not tde_loaded_from_cache:
+                        # Streaming runs cache the okada operator but not the
+                        # dense TDE matrices, so a later non-streaming run
+                        # lands here and must compute them
+                        logger.info(
+                            "Cache missing tde_to_velocities. Computing from scratch."
+                        )
+                        _compute_and_cache_tde_to_velocities(
+                            meshes, station, config, operators, cache
+                        )
+                return
 
         else:
             if not config.force_recompute:
@@ -1626,35 +1740,23 @@ def _store_elastic_operators(
             "No precomputed elastic operator file specified in config. Computing operators."
         )
 
-    operators.slip_rate_to_okada_to_velocities = get_segment_station_operator_okada(
-        segment, station, config
+    operators.rotation_to_slip_rate_to_okada_to_velocities = (
+        _compute_okada_composed_and_cache(
+            segment,
+            station,
+            config,
+            rotation_to_slip_rate,
+            cache,
+            target_bytes,
+            # Streaming runs must not truncate TDE datasets they will not
+            # rebuild; non-streaming recomputes rewrite them anyway, and
+            # truncating avoids unbounded HDF5 file growth
+            preserve_existing=skip_tde_to_velocities,
+        )
     )
 
     if tde and not skip_tde_to_velocities:
-        for i in range(len(meshes)):
-            logger.info(
-                f"Start: TDE slip to velocity calculation for mesh: {meshes[i].file_name}"
-            )
-            operators.tde_to_velocities[i] = get_tde_to_velocities_single_mesh(
-                meshes, station, config, mesh_idx=i
-            )
-            logger.success(
-                f"Finish: TDE slip to velocity calculation for mesh: {meshes[i].file_name}"
-            )
-
-    # Save elastic to velocity matrices
-    if cache is None:
-        return
-    logger.info("Saving elastic operators in cache")
-    cache.parent.mkdir(parents=True, exist_ok=True)
-    _write_elastic_operator_cache(
-        cache,
-        operators,
-        segment,
-        meshes,
-        write_tde=tde and not skip_tde_to_velocities,
-        preserve_existing_tde=skip_tde_to_velocities,
-    )
+        _compute_and_cache_tde_to_velocities(meshes, station, config, operators, cache)
 
 
 def _store_all_mesh_smoothing_matrices(model: Model, operators: _OperatorBuilder):
@@ -2752,11 +2854,40 @@ def _store_eigenvectors_to_tde_slip(model: Model, operators: _OperatorBuilder):
         logger.success(f"Finish: Eigenvectors to TDE slip for mesh: {mesh.file_name}")
 
 
-def _tde_tri_batch_size(target_bytes: int, n_obs: int, n_tris: int) -> int:
-    """Triangles per slab chunk: one column-triple costs 3 * n_obs rows *
-    3 columns * 8 bytes.
+def _column_triple_batch_size(target_bytes: int, n_obs: int, n_sources: int) -> int:
+    """Sources (triangles or segments) per slab chunk: one column-triple costs
+    3 * n_obs rows * 3 columns * 8 bytes.
     """
-    return max(1, min(n_tris, target_bytes // (72 * max(1, n_obs))))
+    return max(1, min(n_sources, target_bytes // (72 * max(1, n_obs))))
+
+
+def _stream_matmul_rows(
+    left,
+    right: np.ndarray,
+    target_bytes: int,
+    *,
+    negate: bool = False,
+    keep_cols: np.ndarray | None = None,
+) -> np.ndarray:
+    """Compute (-)left[:, keep_cols] @ right in row batches of at most target_bytes.
+
+    left may be an np.ndarray or an open h5py.Dataset. Processing contiguous
+    row slabs avoids materializing a kept-column copy of the full matrix (and,
+    for an h5py.Dataset, avoids loading the full matrix at all).
+    """
+    n_rows, n_cols = left.shape
+    out = np.empty((n_rows, right.shape[1]))
+    rows_per_batch = max(1, target_bytes // max(1, 8 * n_cols))
+    for r0 in range(0, n_rows, rows_per_batch):
+        r1 = min(r0 + rows_per_batch, n_rows)
+        # Contiguous row read (cheap for h5py, a view for ndarray); only the
+        # small in-memory slab is fancy-indexed
+        slab = np.asarray(left[r0:r1, :])
+        if keep_cols is not None:
+            slab = slab[:, keep_cols]
+        block = slab @ right
+        out[r0:r1, :] = -block if negate else block
+    return out
 
 
 def _project_tde_rows_to_eigen(
@@ -2765,24 +2896,18 @@ def _project_tde_rows_to_eigen(
     """Compute -tde_to_velocities[:, keep_12] @ eigenvectors_to_tde_slip in row batches.
 
     tde_to_velocities may be an np.ndarray or an open h5py.Dataset of shape
-    (3 * n_stations, 3 * n_tris). Processing station-row slabs of at most
-    target_bytes avoids materializing the (3 * n_stations, 2 * n_tris)
-    kept-column copy that a direct fancy-index would create (and, for an
-    h5py.Dataset, avoids loading the full matrix at all).
+    (3 * n_stations, 3 * n_tris).
     """
-    n_rows, n_cols = tde_to_velocities.shape
+    n_cols = tde_to_velocities.shape[1]
     assert eigenvectors_to_tde_slip.shape[0] == 2 * (n_cols // 3)
     # Slice columns to only strike-slip and dip-slip (exclude tensile)
-    tde_keep_col_index = get_keep_index_12(n_cols)
-    out = np.empty((n_rows, eigenvectors_to_tde_slip.shape[1]))
-    rows_per_batch = max(1, target_bytes // max(1, 8 * n_cols))
-    for r0 in range(0, n_rows, rows_per_batch):
-        r1 = min(r0 + rows_per_batch, n_rows)
-        # Contiguous row read (cheap for h5py, a view for ndarray); only the
-        # small in-memory slab is fancy-indexed
-        slab = np.asarray(tde_to_velocities[r0:r1, :])
-        out[r0:r1, :] = -(slab[:, tde_keep_col_index] @ eigenvectors_to_tde_slip)
-    return out
+    return _stream_matmul_rows(
+        tde_to_velocities,
+        eigenvectors_to_tde_slip,
+        target_bytes,
+        negate=True,
+        keep_cols=get_keep_index_12(n_cols),
+    )
 
 
 def _accumulate_eigen_to_velocities_streaming(
@@ -2810,7 +2935,7 @@ def _accumulate_eigen_to_velocities_streaming(
     assert eigenvectors_to_tde_slip.shape[0] == 2 * n_tris
     out = np.zeros((3 * n_obs, eigenvectors_to_tde_slip.shape[1]))
     if tri_batch_size is None:
-        tri_batch_size = _tde_tri_batch_size(target_bytes, n_obs, n_tris)
+        tri_batch_size = _column_triple_batch_size(target_bytes, n_obs, n_tris)
     tri_batch_size = max(1, min(n_tris, tri_batch_size))
     obs_lon = station.lon.to_numpy()
     obs_lat = station.lat.to_numpy()
@@ -2884,16 +3009,22 @@ def _compute_eigen_to_velocities(
         result = None
         if streaming:
             if cache is not None and cache.exists():
-                with h5py.File(str(cache), "r") as hdf5_file:
-                    cached_data = hdf5_file.get("tde_to_velocities_" + str(i))
-                    if cached_data is not None:
-                        logger.info(
-                            "Projecting cached tde_to_velocities for mesh: "
-                            f"{meshes[i].file_name}"
-                        )
-                        result = _project_tde_rows_to_eigen(
-                            cached_data, eigenvectors_to_tde_slip, target_bytes
-                        )
+                try:
+                    with h5py.File(str(cache), "r") as hdf5_file:
+                        cached_data = hdf5_file.get("tde_to_velocities_" + str(i))
+                        if cached_data is not None:
+                            logger.info(
+                                "Projecting cached tde_to_velocities for mesh: "
+                                f"{meshes[i].file_name}"
+                            )
+                            result = _project_tde_rows_to_eigen(
+                                cached_data, eigenvectors_to_tde_slip, target_bytes
+                            )
+                except OSError:
+                    logger.warning(
+                        "Cache file unreadable (corrupt or locked by a "
+                        "concurrent run). Computing eigen_to_velocities."
+                    )
             if result is None:
                 logger.info(
                     f"Computing eigen_to_velocities for mesh: {meshes[i].file_name}"

--- a/celeri/output.py
+++ b/celeri/output.py
@@ -326,12 +326,19 @@ def dataclass_from_disk(
     store = zarr.open_group(str(data_file), mode="r")
     data: dict[str, Any] = {}
     for name in store.array_keys():
+        if name in skip:
+            # Skipped keys must not be materialized at all: skipped arrays can
+            # be large (e.g. dense operators in run folders written by older
+            # versions)
+            continue
         if name in extra:
             raise ValueError(f"Duplicate key '{name}' found in extra data.")
         values = store[name]
         assert isinstance(values, zarr.Array)
         data[name] = values[...]
     for name in store.group_keys():
+        if name in skip:
+            continue
         values = store[name]
         assert isinstance(values, zarr.Group)
         arrays = {}

--- a/celeri/spatial.py
+++ b/celeri/spatial.py
@@ -158,10 +158,7 @@ def get_segment_station_operator_okada(segment, station, config, *, progress_bar
 
     """
     if station.empty:
-        # TODO: Shouldn't this return an array of shape (0, 3 * n_segments)?
-        # Currently this returns an array of shape (1,) with an uninitialized value,
-        # so this seems wrong.
-        return np.empty(1)
+        return np.zeros((0, 3 * len(segment)))
     n_segments = len(segment)
     n_stations = len(station)
     okada_segment_operator = np.full((3 * n_stations, 3 * n_segments), np.nan)
@@ -172,7 +169,39 @@ def get_segment_station_operator_okada(segment, station, config, *, progress_bar
         else track(range(len(segment)), description="Rectangular segment elastic")
     )
     for i in segment_iter:
-        for slip_type in ["strike", "dip", "tensile"]:
+        get_okada_displacement_slab(
+            segment,
+            station,
+            config,
+            seg_start=i,
+            seg_stop=i + 1,
+            out=okada_segment_operator[:, 3 * i : 3 * i + 3],
+        )
+    return okada_segment_operator
+
+
+def get_okada_displacement_slab(
+    segment, station, config, *, seg_start, seg_stop, out=None
+):
+    """Dense displacement columns for segments [seg_start, seg_stop).
+
+    Returns a (3 * n_stations, 3 * (seg_stop - seg_start)) float64 array. For
+    local segment j = i - seg_start, column 3*j is the response to unit strike
+    slip, 3*j + 1 to unit dip slip, and 3*j + 2 to unit tensile slip. Rows
+    interleave (east, north, up) per station, matching the layout documented
+    in get_segment_station_operator_okada. If out is given, the columns are
+    written into it (it must have the shape above) and it is returned.
+    """
+    n_stations = len(station)
+    if out is None:
+        out = np.empty((3 * n_stations, 3 * (seg_stop - seg_start)))
+    else:
+        assert out.shape == (3 * n_stations, 3 * (seg_stop - seg_start))
+    # seg_start/seg_stop are positional; the column reads below are label-based
+    if not segment.index.equals(pd.RangeIndex(len(segment))):
+        segment = segment.reset_index(drop=True)
+    for j, i in enumerate(range(seg_start, seg_stop)):
+        for k, slip_type in enumerate(["strike", "dip", "tensile"]):
             # Each `u` has shape (n_stations, )
             u_east, u_north, u_up = get_okada_displacements(
                 segment.lon1[i],
@@ -190,20 +219,13 @@ def get_segment_station_operator_okada(segment, station, config, *, progress_bar
                 station.lon,
                 station.lat,
             )
-            if slip_type == "strike":
-                col_idx = 3 * i
-            elif slip_type == "dip":
-                col_idx = 3 * i + 1
-            elif slip_type == "tensile":
-                col_idx = 3 * i + 2
-            else:
-                raise ValueError(f"Invalid slip type: {slip_type}")
+            col_idx = 3 * j + k
             # The i::3 notation sets an offset of i and a skip of 3 so that
             # east/north/up displacements are interleaved.
-            okada_segment_operator[0::3, col_idx] = np.squeeze(u_east)
-            okada_segment_operator[1::3, col_idx] = np.squeeze(u_north)
-            okada_segment_operator[2::3, col_idx] = np.squeeze(u_up)
-    return okada_segment_operator
+            out[0::3, col_idx] = np.squeeze(u_east)
+            out[1::3, col_idx] = np.squeeze(u_north)
+            out[2::3, col_idx] = np.squeeze(u_up)
+    return out
 
 
 def get_okada_displacements(

--- a/scripts/bench_okada_memory.py
+++ b/scripts/bench_okada_memory.py
@@ -1,0 +1,144 @@
+"""Peak-memory benchmark: dense vs streamed Okada composition.
+
+Compares the pre-refactor computation (materialize the full
+(3 * n_stations, 3 * n_segments) okada operator, then one matmul against
+rotation_to_slip_rate) with the streamed paths: segment-chunk accumulation
+(no cache) and row-slab streaming from an HDF5 cache dataset.
+
+Each variant runs in its own subprocess because ru_maxrss is a
+process-lifetime high-water mark. Checksums must agree to ~1e-6 relative.
+
+Usage:
+    pixi run python scripts/bench_okada_memory.py                 # all variants
+    pixi run python scripts/bench_okada_memory.py --n-stations 25000
+    pixi run python scripts/bench_okada_memory.py --variant dense
+"""
+
+import argparse
+import resource
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+import numpy as np
+
+CONFIG = "tests/configs/test_wna_config.json"
+
+
+def synthetic_stations(model, n_stations, seed=0):
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(0, len(model.station), n_stations)
+    station = model.station.iloc[idx].reset_index(drop=True).copy()
+    station["lon"] += rng.uniform(-0.05, 0.05, n_stations)
+    station["lat"] += rng.uniform(-0.05, 0.05, n_stations)
+    return station
+
+
+def run_variant(variant, n_stations, budget_gb):
+    import h5py
+
+    import celeri
+    from celeri.operators import (
+        _compute_okada_composed_and_cache,
+        _stream_matmul_rows,
+    )
+    from celeri.spatial import (
+        get_rotation_to_slip_rate_partials,
+        get_segment_station_operator_okada,
+    )
+
+    config = celeri.get_config(CONFIG)
+    config.elastic_operator_cache_dir = None
+    config.tde_operator_memory_gb = budget_gb
+    model = celeri.build_model(config)
+    station = synthetic_stations(model, n_stations)
+    rotation_to_slip_rate = get_rotation_to_slip_rate_partials(
+        model.segment, model.block
+    )
+    n_segments = len(model.segment)
+    dense_gb = (3 * n_stations) * (3 * n_segments) * 8 / 2**30
+    target_bytes = int(budget_gb * 2**30)
+
+    start = time.perf_counter()
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    if variant == "dense":
+        okada = get_segment_station_operator_okada(model.segment, station, config)
+        result = okada @ rotation_to_slip_rate
+    elif variant == "streamed":
+        result = _compute_okada_composed_and_cache(
+            model.segment, station, config, rotation_to_slip_rate, None, target_bytes
+        )
+    elif variant == "cachestream":
+        # Dense dataset written outside the measured window (setup), then the
+        # row-slab streaming path is measured
+        tracemalloc.stop()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = Path(tmpdir) / "okada.hdf5"
+            okada = get_segment_station_operator_okada(model.segment, station, config)
+            with h5py.File(str(cache), "w") as hdf5_file:
+                hdf5_file.create_dataset("slip_rate_to_okada_to_velocities", data=okada)
+            del okada
+            start = time.perf_counter()
+            tracemalloc.start()
+            tracemalloc.reset_peak()
+            with h5py.File(str(cache), "r") as hdf5_file:
+                result = _stream_matmul_rows(
+                    hdf5_file["slip_rate_to_okada_to_velocities"],
+                    rotation_to_slip_rate,
+                    target_bytes,
+                )
+    else:
+        raise ValueError(variant)
+    _, tm_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    elapsed = time.perf_counter() - start
+
+    ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform != "darwin":
+        ru_maxrss *= 1024  # linux reports KiB, macOS reports bytes
+    print(
+        f"{variant:>12s}  n_stations={n_stations}  n_segments={n_segments}  "
+        f"dense_equiv={dense_gb:6.2f} GiB  "
+        f"tracemalloc_peak={tm_peak / 2**30:6.2f} GiB  "
+        f"ru_maxrss={ru_maxrss / 2**30:6.2f} GiB  "
+        f"wall={elapsed:7.1f} s  "
+        # abs-sum: the plain sum of the composed operator nearly cancels, so
+        # it cannot serve as a cross-variant comparator
+        f"checksum={np.abs(result).sum():.17g}",
+        flush=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=["dense", "streamed", "cachestream"])
+    parser.add_argument("--n-stations", type=int, default=25000)
+    parser.add_argument("--budget-gb", type=float, default=0.25)
+    args = parser.parse_args()
+
+    if args.variant is not None:
+        run_variant(args.variant, args.n_stations, args.budget_gb)
+        return
+
+    for variant in ("dense", "streamed", "cachestream"):
+        subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--variant",
+                variant,
+                "--n-stations",
+                str(args.n_stations),
+                "--budget-gb",
+                str(args.budget_gb),
+            ],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_solve_dense.py
+++ b/tests/test_solve_dense.py
@@ -94,9 +94,23 @@ def test_operator_slip_rate_to_okada_to_velocities(config_name):
 
     estimation = celeri.assemble_and_solve_dense(model, eigen=True, tde=True)
 
-    assert estimation.operators.slip_rate_to_okada_to_velocities is not None
+    # The dense okada operator is no longer kept on the Operators object; the
+    # solve consumes only the composed rotation product. Rebuild the dense
+    # matrix with the (unchanged) assembler to compare against the same
+    # baseline, and tie the streamed composed operator back to it.
+    assert estimation.operators.slip_rate_to_okada_to_velocities is None
+    operator = celeri.get_segment_station_operator_okada(
+        model.segment, model.station, model.config, progress_bar=False
+    )
+    composed_reference = operator @ estimation.operators.rotation_to_slip_rate
+    composed = estimation.operators.rotation_to_slip_rate_to_okada_to_velocities
+    np.testing.assert_allclose(
+        composed,
+        composed_reference,
+        rtol=1e-10,
+        atol=1e-12 * np.abs(composed_reference).max(),
+    )
 
-    operator = estimation.operators.slip_rate_to_okada_to_velocities
     rng = np.random.default_rng(seed=0)
     size = min(min(len(operator), len(operator[0])), 50)
     idx_rows = rng.choice(len(operator), size=size, replace=False)

--- a/tests/test_streamed_okada.py
+++ b/tests/test_streamed_okada.py
@@ -1,0 +1,610 @@
+"""Tests for the streamed Okada segment operator construction.
+
+The dense (3 * n_stations, 3 * n_segments) okada operator is no longer held in
+memory: only the composed okada @ rotation_to_slip_rate product is built,
+either by accumulating segment-chunk slabs (no cache configured) or by
+streaming row slabs from the HDF5 cache dataset, which is filled slab-by-slab
+on a cache miss and updated in place by selective recompute. These tests pin:
+  1. Bitwise equality of the slab helper against the dense assembler.
+  2. Numerical equivalence of both composed-product paths against the dense
+     composition, across chunk-size edge cases.
+  3. Cache behavior: bitwise miss/hit equality, legacy caches readable, new
+     caches readable the old way, segment validation before any matrix read,
+     in-place selective recompute.
+  4. Serialization: the always-None dense field round-trips, and legacy run
+     folders containing the dense array load without materializing it.
+  5. tracemalloc guards that neither composed path approaches the dense
+     matrix footprint.
+
+Composed-operator comparisons use a matrix-scaled absolute tolerance:
+rotation_to_slip_rate is [m/rad] with entries up to ~6e6, so composed entries
+are O(1e6) and bare atol=1e-10 would be unrealistically tight.
+"""
+
+import tracemalloc
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+import zarr
+
+import celeri
+from celeri.operators import (
+    LosOperators,
+    Operators,
+    _compute_okada_composed_and_cache,
+    _hash_elastic_operator_input,
+    _load_segments_from_hdf5,
+    _project_operator_to_los,
+    _stream_matmul_rows,
+    build_los_operators,
+    build_operators,
+)
+from celeri.spatial import (
+    get_okada_displacement_slab,
+    get_rotation_to_slip_rate_partials,
+    get_segment_station_operator_okada,
+)
+
+WNA_CONFIG = "tests/configs/test_wna_config.json"
+OKADA_KEY = "slip_rate_to_okada_to_velocities"
+
+
+def _station_subset(config, n_stations):
+    """First n stations that survive processing (process_station drops flag == 0)."""
+    station = pd.read_csv(config.station_file_name)
+    return station[station.flag != 0].iloc[:n_stations].reset_index(drop=True)
+
+
+def _wna_model(n_stations, cache_dir=None, **build_kwargs):
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = cache_dir
+    station = _station_subset(config, n_stations)
+    return celeri.build_model(config, override_station=station, **build_kwargs)
+
+
+def _scaled_tol(reference):
+    return {"rtol": 1e-10, "atol": 1e-12 * np.abs(reference).max()}
+
+
+def _cache_path(model):
+    input_hash = _hash_elastic_operator_input(
+        [mesh.config for mesh in model.meshes], model.station, model.config
+    )
+    return model.config.elastic_operator_cache_dir / f"{input_hash}.hdf5"
+
+
+def _dense_okada(model):
+    return get_segment_station_operator_okada(
+        model.segment, model.station, model.config, progress_bar=False
+    )
+
+
+@pytest.fixture(scope="module")
+def wna_model():
+    """25-station wna model (837 segments, 31 blocks)."""
+    return _wna_model(25)
+
+
+@pytest.fixture(scope="module")
+def wna_dense(wna_model):
+    """The dense okada operator (the object the refactor keeps out of RAM)."""
+    return _dense_okada(wna_model)
+
+
+@pytest.fixture(scope="module")
+def wna_rotation(wna_model):
+    return get_rotation_to_slip_rate_partials(wna_model.segment, wna_model.block)
+
+
+@pytest.fixture(scope="module")
+def wna_composed_reference(wna_dense, wna_rotation):
+    """The pre-refactor composition: full dense matrix @ rotation partials."""
+    return wna_dense @ wna_rotation
+
+
+def test_okada_slab_bitwise_equals_dense_assembler(wna_model, wna_dense):
+    """The slab helper must reproduce the dense assembler columns bitwise:
+    this is what keeps the arraydiff baseline and every cache dataset
+    bit-identical across the refactor.
+    """
+    n_segments = len(wna_model.segment)
+    for seg_start, seg_stop in [
+        (0, 1),
+        (17, 18),
+        (n_segments - 1, n_segments),
+        (3, 11),
+    ]:
+        slab = get_okada_displacement_slab(
+            wna_model.segment,
+            wna_model.station,
+            wna_model.config,
+            seg_start=seg_start,
+            seg_stop=seg_stop,
+        )
+        assert np.array_equal(slab, wna_dense[:, 3 * seg_start : 3 * seg_stop])
+
+
+@pytest.mark.parametrize("seg_batch", [1, 7, "exact", "oversize"])
+def test_accumulation_matches_dense_composition(
+    wna_model, wna_rotation, wna_composed_reference, seg_batch
+):
+    """No-cache path: segment-chunk accumulation must match the dense
+    composition for degenerate, non-divisor, exact, and oversize chunk sizes
+    (chunk size is driven through the memory budget).
+    """
+    n_stations = len(wna_model.station)
+    n_segments = len(wna_model.segment)
+    batch = {"exact": n_segments, "oversize": n_segments + 13}.get(seg_batch, seg_batch)
+    result = _compute_okada_composed_and_cache(
+        wna_model.segment,
+        wna_model.station,
+        wna_model.config,
+        wna_rotation,
+        cache=None,
+        target_bytes=batch * 72 * n_stations,
+    )
+    assert result.shape == (3 * n_stations, wna_rotation.shape[1])
+    np.testing.assert_allclose(
+        result, wna_composed_reference, **_scaled_tol(wna_composed_reference)
+    )
+
+
+@pytest.mark.parametrize("rows_per_batch", [1, 7, 10**9])
+def test_row_slab_stream_matches_dense_composition(
+    tmp_path, wna_dense, wna_rotation, wna_composed_reference, rows_per_batch
+):
+    """Cache-hit path: row-slab streaming from an HDF5 dataset must match the
+    dense composition for degenerate, non-divisor, and single-batch slabs.
+    """
+    with h5py.File(tmp_path / "cache.hdf5", "w") as hdf5_file:
+        hdf5_file.create_dataset(OKADA_KEY, data=wna_dense)
+    with h5py.File(tmp_path / "cache.hdf5", "r") as hdf5_file:
+        result = _stream_matmul_rows(
+            hdf5_file[OKADA_KEY],
+            wna_rotation,
+            rows_per_batch * 8 * wna_dense.shape[1],
+        )
+    np.testing.assert_allclose(
+        result,
+        wna_composed_reference,
+        rtol=1e-12,
+        atol=1e-14 * np.abs(wna_composed_reference).max(),
+    )
+
+
+def test_streamed_build_matches_dense_reference_end_to_end(tmp_path):
+    """build_operators: the dense field is None, the composed operator matches
+    the dense composition, and cache-miss and cache-hit builds are bitwise
+    equal (the miss path re-streams from the completed dataset).
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops_miss = build_operators(model, eigen=True, tde=True)
+    assert ops_miss.slip_rate_to_okada_to_velocities is None
+
+    dense = _dense_okada(model)
+    reference = dense @ ops_miss.rotation_to_slip_rate
+    np.testing.assert_allclose(
+        ops_miss.rotation_to_slip_rate_to_okada_to_velocities,
+        reference,
+        **_scaled_tol(reference),
+    )
+
+    ops_hit = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops_hit.rotation_to_slip_rate_to_okada_to_velocities,
+        ops_miss.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_build_reads_legacy_okada_cache(tmp_path):
+    """A contiguous full-matrix dataset written the pre-refactor way must be
+    consumed by the streaming path. The cached matrix is scaled by 2 so the
+    test proves the cache (not a recompute) was the source of the result.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r+") as hdf5_file:
+        dense = np.array(hdf5_file[OKADA_KEY])
+        del hdf5_file[OKADA_KEY]
+        # data= writes the legacy contiguous layout
+        hdf5_file.create_dataset(OKADA_KEY, data=2.0 * dense)
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        2.0 * ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_new_cache_dataset_readable_the_old_way(tmp_path, wna_dense):
+    """The slab-filled chunked dataset must hold exactly the dense assembly
+    (no NaN holes from partial fills) and remain loadable via a plain
+    np.array read, with segment metadata present.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    build_operators(model, eigen=True, tde=True)
+    with h5py.File(_cache_path(model), "r") as hdf5_file:
+        arr = np.array(hdf5_file[OKADA_KEY])
+        assert arr.shape == wna_dense.shape
+        assert not np.isnan(arr).any()
+        assert np.array_equal(arr, wna_dense)
+        cached_segments = _load_segments_from_hdf5(hdf5_file)
+        assert cached_segments is not None
+        assert cached_segments["name"].tolist() == model.segment["name"].tolist()
+
+
+def test_selective_recompute_updates_cache_in_place(tmp_path):
+    """A segment edit must update only the changed column triples of the cache
+    dataset in place (no full rewrite, no file-size blowup) and produce a
+    composed operator equal to a from-scratch build.
+    """
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = tmp_path
+    station = _station_subset(config, 25)
+    model = celeri.build_model(config, override_station=station)
+    build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r") as hdf5_file:
+        unchanged_snapshot = np.array(hdf5_file[OKADA_KEY][:, 9:12])  # segment 3
+    size_before = cache.stat().st_size
+
+    changed = [0, 5, 11]
+    segment = model.segment.copy(deep=True)
+    for idx in changed:
+        segment.loc[idx, "locking_depth"] = (
+            float(segment.loc[idx, "locking_depth"]) + 1.0
+        )
+    model2 = celeri.build_model(
+        config, override_station=station, override_segment=segment
+    )
+    ops_sel = build_operators(model2, eigen=True, tde=True)
+
+    # In-place update: only metadata churn, no dataset rewrite
+    assert cache.stat().st_size <= size_before + 2 * 2**20
+    with h5py.File(cache, "r") as hdf5_file:
+        dataset = hdf5_file[OKADA_KEY]
+        assert np.array_equal(dataset[:, 9:12], unchanged_snapshot)
+        for idx in changed:
+            fresh = get_okada_displacement_slab(
+                model2.segment,
+                model2.station,
+                model2.config,
+                seg_start=idx,
+                seg_stop=idx + 1,
+            )
+            assert np.array_equal(dataset[:, 3 * idx : 3 * idx + 3], fresh)
+
+    dense2 = _dense_okada(model2)
+    reference = dense2 @ ops_sel.rotation_to_slip_rate
+    np.testing.assert_allclose(
+        ops_sel.rotation_to_slip_rate_to_okada_to_velocities,
+        reference,
+        **_scaled_tol(reference),
+    )
+
+
+def test_segment_rename_recomputes_without_reading_matrix(tmp_path):
+    """When segment names change, the cache must be invalidated by metadata
+    alone: a deliberately poisoned (garbage-shaped) dataset must never be
+    read, and the rebuild must succeed.
+    """
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = tmp_path
+    station = _station_subset(config, 25)
+    model = celeri.build_model(config, override_station=station)
+    build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r+") as hdf5_file:
+        del hdf5_file[OKADA_KEY]
+        hdf5_file.create_dataset(OKADA_KEY, data=np.zeros(1))
+
+    segment = model.segment.copy(deep=True)
+    segment.loc[0, "name"] = "renamed_segment_for_test"
+    model2 = celeri.build_model(
+        config, override_station=station, override_segment=segment
+    )
+    ops = build_operators(model2, eigen=True, tde=True)
+    dense = _dense_okada(model2)
+    reference = dense @ ops.rotation_to_slip_rate
+    np.testing.assert_allclose(
+        ops.rotation_to_slip_rate_to_okada_to_velocities,
+        reference,
+        **_scaled_tol(reference),
+    )
+
+
+def test_mismatched_dataset_triggers_recompute(tmp_path):
+    """A cache whose okada dataset has the wrong shape (e.g. a crash artifact)
+    must trigger a clean recompute even when segments are unchanged.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r+") as hdf5_file:
+        del hdf5_file[OKADA_KEY]
+        hdf5_file.create_dataset(OKADA_KEY, data=np.zeros(1))
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_corrupt_cache_file_recovers(tmp_path):
+    """A cache file that is not valid HDF5 at all (e.g. truncated by a killed
+    run or a full disk) must be recreated, not crash every subsequent run.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    cache.write_bytes(b"this is not an hdf5 file")
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+    # The file was recreated as a valid cache
+    with h5py.File(cache, "r") as hdf5_file:
+        assert OKADA_KEY in hdf5_file
+
+
+def test_cache_missing_names_dataset_recomputes(tmp_path):
+    """A cache holding segments but not segments_names (crash window inside
+    the metadata write) must read as old-format and recompute cleanly rather
+    than raising KeyError on the missing name column.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r+") as hdf5_file:
+        del hdf5_file["segments_names"]
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_interrupted_selective_recompute_recovers(tmp_path):
+    """Simulate the crash window of an in-place selective recompute: metadata
+    invalidated, one column already overwritten with new-geometry values, then
+    the run dies and the user reverts the segment edit. The next run must
+    recompute (metadata absent) instead of serving the corrupted column.
+    """
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = tmp_path
+    station = _station_subset(config, 25)
+    model = celeri.build_model(config, override_station=station)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    # Crash state: metadata deleted (the fixed ordering deletes it first),
+    # column 0 poisoned mid-update
+    with h5py.File(cache, "r+") as hdf5_file:
+        for key in ("segments", "segments_names"):
+            del hdf5_file[key]
+        hdf5_file[OKADA_KEY][:, 0:3] = 12345.0
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_cache_without_segment_metadata_recomputes(tmp_path):
+    """A cache missing the segments metadata (e.g. a crash before the
+    metadata-last write) must read as old-format and recompute cleanly.
+    """
+    model = _wna_model(25, cache_dir=tmp_path)
+    ops1 = build_operators(model, eigen=True, tde=True)
+    cache = _cache_path(model)
+    with h5py.File(cache, "r+") as hdf5_file:
+        for key in ("segments", "segments_names"):
+            if key in hdf5_file:
+                del hdf5_file[key]
+
+    ops2 = build_operators(model, eigen=True, tde=True)
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops1.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def _synthetic_los(station, n_los=12, seed=7):
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(0, len(station), n_los)
+    look = rng.normal(size=(n_los, 3))
+    look /= np.linalg.norm(look, axis=1, keepdims=True)
+    return pd.DataFrame(
+        {
+            "lon": station.lon.to_numpy()[idx] + rng.uniform(-0.1, 0.1, n_los),
+            "lat": station.lat.to_numpy()[idx] + rng.uniform(-0.1, 0.1, n_los),
+            "los_val": rng.normal(size=n_los),
+            "look_vector_east": look[:, 0],
+            "look_vector_north": look[:, 1],
+            "look_vector_up": look[:, 2],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def wna_los_model():
+    config = celeri.get_config(WNA_CONFIG)
+    config.elastic_operator_cache_dir = None
+    station = _station_subset(config, 25)
+    model = celeri.build_model(config, override_station=station)
+    los = _synthetic_los(model.station)
+    return celeri.build_model(config, override_station=station, override_los=los)
+
+
+@pytest.fixture(scope="module")
+def wna_los_operators(wna_los_model):
+    ops = build_operators(wna_los_model, eigen=True, tde=True)
+    los_ops = build_los_operators(wna_los_model, ops)
+    assert los_ops is not None
+    return ops, los_ops
+
+
+def test_los_rotation_to_okada_matches_dense_reference(
+    wna_los_model, wna_los_operators
+):
+    """LOS path: the chunk-accumulated rotation_to_okada_los must match the
+    dense project-then-compose reference; raw okada_to_los is no longer
+    stored.
+    """
+    ops, los_ops = wna_los_operators
+    model = wna_los_model
+    assert los_ops.okada_to_los is None
+
+    okada_at_los = get_segment_station_operator_okada(
+        model.segment, model.los, model.config, progress_bar=False
+    )
+    look_vectors = np.column_stack(
+        [
+            model.los.look_vector_east.to_numpy(),
+            model.los.look_vector_north.to_numpy(),
+            model.los.look_vector_up.to_numpy(),
+        ]
+    )
+    reference = _project_operator_to_los(
+        okada_at_los @ ops.rotation_to_slip_rate, look_vectors
+    )
+    np.testing.assert_allclose(
+        los_ops.rotation_to_okada_los,
+        reference,
+        rtol=1e-9,
+        atol=1e-10 * np.abs(reference).max(),
+    )
+
+
+def test_los_operators_roundtrip_and_legacy_okada_to_los(tmp_path, wna_los_operators):
+    """LosOperators round-trips with okada_to_los None, and a legacy los
+    folder containing an okada_to_los array loads with the field skipped.
+    """
+    _, los_ops = wna_los_operators
+    out = tmp_path / "los"
+    los_ops.to_disk(out)
+    store = zarr.open_group(str(out / "arrays.zarr"), mode="r")
+    assert "okada_to_los" not in set(store.array_keys())
+    reloaded = LosOperators.from_disk(out)
+    assert reloaded.okada_to_los is None
+    np.testing.assert_array_equal(
+        reloaded.rotation_to_okada_los, los_ops.rotation_to_okada_los
+    )
+
+    # Retrofit a legacy-format folder with the dense LOS okada array present
+    legacy = zarr.open_group(str(out / "arrays.zarr"), mode="a")
+    dense_los_okada = np.ones((los_ops.n_los, 9))
+    array_store = legacy.create_array(
+        "okada_to_los", shape=dense_los_okada.shape, dtype=dense_los_okada.dtype
+    )
+    array_store[...] = dense_los_okada
+    reloaded2 = LosOperators.from_disk(out)
+    assert reloaded2.okada_to_los is None
+
+
+def test_operators_roundtrip_with_none_okada(tmp_path):
+    """Operators round-trips with the dense okada field None: nothing is
+    written for it, and from_disk restores None.
+    """
+    model = _wna_model(25)
+    ops = build_operators(model, eigen=True, tde=True)
+    out = tmp_path / "operators"
+    ops.to_disk(out)
+
+    store = zarr.open_group(str(out / "arrays.zarr"), mode="r")
+    keys = set(store.array_keys())
+    assert "slip_rate_to_okada_to_velocities" not in keys
+    assert "rotation_to_slip_rate_to_okada_to_velocities" in keys
+
+    ops2 = Operators.from_disk(out)
+    assert ops2.slip_rate_to_okada_to_velocities is None
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_from_disk_legacy_run_folder_with_dense_okada(tmp_path, wna_dense):
+    """A run folder written by an older version contains the dense okada array
+    in arrays.zarr; loading must skip it without materializing.
+    """
+    model = _wna_model(25)
+    ops = build_operators(model, eigen=True, tde=True)
+    out = tmp_path / "operators"
+    ops.to_disk(out)
+
+    legacy = zarr.open_group(str(out / "arrays.zarr"), mode="a")
+    array_store = legacy.create_array(
+        "slip_rate_to_okada_to_velocities",
+        shape=wna_dense.shape,
+        dtype=wna_dense.dtype,
+    )
+    array_store[...] = wna_dense
+
+    ops2 = Operators.from_disk(out)
+    assert ops2.slip_rate_to_okada_to_velocities is None
+    np.testing.assert_array_equal(
+        ops2.rotation_to_slip_rate_to_okada_to_velocities,
+        ops.rotation_to_slip_rate_to_okada_to_velocities,
+    )
+
+
+def test_streamed_composition_peak_memory_stays_below_dense():
+    """Regression guard: with a small memory budget, the accumulate path must
+    never come close to materializing the dense okada matrix.
+    """
+    model = _wna_model(400)
+    rotation = get_rotation_to_slip_rate_partials(model.segment, model.block)
+    n_stations = len(model.station)
+    n_segments = len(model.segment)
+    dense_bytes = (3 * n_stations) * (3 * n_segments) * 8
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    result = _compute_okada_composed_and_cache(
+        model.segment,
+        model.station,
+        model.config,
+        rotation,
+        cache=None,
+        target_bytes=dense_bytes // 20,
+    )
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert result.shape == (3 * n_stations, rotation.shape[1])
+    assert peak < dense_bytes / 3, (
+        f"accumulate peak {peak / 2**20:.1f} MiB vs dense {dense_bytes / 2**20:.1f} MiB"
+    )
+
+
+def test_cache_hit_stream_peak_memory_stays_below_dense(tmp_path):
+    """Regression guard for the cache-hit path: row-slab streaming must stay
+    far below the dense matrix footprint.
+    """
+    model = _wna_model(400)
+    rotation = get_rotation_to_slip_rate_partials(model.segment, model.block)
+    dense = _dense_okada(model)
+    dense_bytes = dense.nbytes
+    with h5py.File(tmp_path / "cache.hdf5", "w") as hdf5_file:
+        hdf5_file.create_dataset(OKADA_KEY, data=dense)
+    del dense
+
+    with h5py.File(tmp_path / "cache.hdf5", "r") as hdf5_file:
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        result = _stream_matmul_rows(hdf5_file[OKADA_KEY], rotation, dense_bytes // 20)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+    assert result.shape[1] == rotation.shape[1]
+    assert peak < dense_bytes / 3, (
+        f"stream peak {peak / 2**20:.1f} MiB vs dense {dense_bytes / 2**20:.1f} MiB"
+    )


### PR DESCRIPTION
Follow-up to #487 (issue #485): after the TDE streaming fix, the dense Okada segment operator `(3·n_stations, 3·n_segments)` — ~29 GiB at 100k stations — became the memory ceiling of streaming operator construction, even though every runtime consumer only ever uses the composed `okada @ rotation_to_slip_rate` product (`(3·n_stations, 3·n_blocks)` ≈ 0.65 GiB; verified by exhaustive consumer trace: no per-segment free parameters exist anywhere, and the full matrix on the finalized `Operators` object had zero runtime readers).

## What changed

- **The dense matrix now lives only in the elastic-operator cache file.** `Operators.slip_rate_to_okada_to_velocities` is always `None` (field retained for backward compatibility); same for the never-consumed `LosOperators.okada_to_los`.
- **spatial.py**: new `get_okada_displacement_slab` emits column-triples for a segment range (bitwise-identical to the dense assembler, which now delegates to it); the `station.empty` case returns the documented `(0, 3·n_segments)` shape instead of `np.empty(1)`.
- **operators.py**: shared `_stream_matmul_rows` primitive (row-slab streaming over ndarray or h5py.Dataset; the TDE projection from #487 is now a thin wrapper over it). `_store_elastic_operators`:
  - validates cached segment metadata **before** touching the matrix (previously the 29 GiB dataset was loaded in full before segment comparison, plus a `.copy()` → ~58 GiB transient during selective recompute);
  - cache hit → composed product streamed in row slabs from the open dataset;
  - cache miss → chunked dataset filled slab-by-slab, then the composed product is re-streamed from the completed dataset, making **cache-miss and cache-hit results bitwise equal** (the documented cost: one extra sequential read of the dataset);
  - segment edits → changed column-triples written **in place** (`r+`), metadata invalidated before and rewritten after the update so an interrupted run recomputes cleanly; no more full-file rewrites (and no more HDF5 space leak);
  - corrupt or concurrently-locked cache files are tolerated everywhere: unreadable files are recreated, locked files degrade to computing without caching (previously: crash, and `force_recompute` couldn't recover a corrupt file).
- **LOS**: `rotation_to_okada_los` is chunk-accumulated; the dense per-segment LOS operator is never materialized.
- **Serialization**: run folders no longer contain the dense array (~29 GiB smaller at 100k); `dataclass_from_disk` now skips keys **before** materializing zarr arrays, so old run folders that do contain it load without pulling it into memory.

## Measured on the 100k WNA model (100,592 stations, 3,978 segments, 186 meshes)

| | before (#487) | after |
|---|---|---|
| full streaming operator construction, peak RSS | 47.2 GiB | **19.7 GiB** |
| wall time (warm okada cache) | 76.6 min | **64.0 min** |
| segment edit (selective recompute) | full 29 GiB load + ~58 GiB transient copy + full file rewrite | **24 s**, in place, file size unchanged, unchanged columns bitwise preserved |

Remaining peak is the resident `eigen_to_velocities` dict (11.1 GiB) plus model overhead — the next (much smaller) ceiling, tracked separately. At 250k stations the projected peak is now ~40 GiB instead of ~95+.

Micro-benchmark (`scripts/bench_okada_memory.py`, 20k synthetic stations): dense path 1.17 GiB / streamed 0.19 GiB, identical checksums.

## Testing

- `tests/test_solve_dense.py --arraydiff`: 31/31 against **unchanged baselines** (the okada arraydiff test now rebuilds its sampled block from the dense assembler, which is bitwise-identical — pinned by a dedicated test).
- New `tests/test_streamed_okada.py` (25 tests): bitwise slab guard; both composed paths vs the dense composition across chunk-size edge cases (matrix-scaled tolerances); bitwise miss==hit; legacy contiguous caches readable by the new code and new chunked caches readable by old `np.array` loads; scaled-cache probe proving the cache is the source; poisoned-dataset and renamed-segment probes proving validation precedes any matrix read; in-place selective recompute (file-size guard, bitwise unchanged columns, fresh-vs-cached changed columns); corrupt-file recovery; interrupted-update recovery; missing-metadata recovery; serialization round-trips incl. legacy run folders; tracemalloc guards on both streamed paths.
- `test_cache.py::test_smart_segment_recompute` passes **unmodified** (in-place updates keep dataset-level equality); test_batched_eigen, serialize, output-files, mcmc, optimize, legacy-mcmc suites all green.
- An adversarial multi-agent review of the diff ran before finalizing; all confirmed findings (interrupted-update crash window, corrupt-cache recoverability, concurrent-run locking behavior, partial-TDE-dataset sentinel, cache file growth) are fixed and pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)