### PR TITLE
Convert CLI filenames from str to Path

### DIFF
--- a/celeri/cli.py
+++ b/celeri/cli.py
@@ -323,6 +323,10 @@ def process_args(config: Config, args: argparse.Namespace):
                 if isinstance(args_val, bool) and isinstance(original_val, int | float):
                     original_val = bool(original_val)
 
+                # Convert CLI filenames from cwd-relative str to absolute Path
+                if key[-10:] == "_file_name":
+                    args_val = Path(args_val).absolute()
+
                 # Only log if the value is actually being changed
                 if original_val != args_val:
                     logger.warning(f"ORIGINAL: config.{key}: {original_val}")

--- a/tests/test_process_args.py
+++ b/tests/test_process_args.py
@@ -44,7 +44,8 @@ def test_mesh_parameters_file_name_override_reloads_mesh_params(tmp_path):
     process_args(config, args)
 
     # Both the path field AND the actual loaded parameters must reflect the alt file.
-    assert config.mesh_parameters_file_name == str(alt)
+    # Assertion of filename now removes str(alt) because CLI filenames get converted to Path (PR #490)
+    assert config.mesh_parameters_file_name == alt
     assert config.mesh_params, "mesh_params should be non-empty"
     for mesh_param in config.mesh_params:
         assert mesh_param.n_modes_strike_slip == 7


### PR DESCRIPTION
CLI-specified filenames are written to the output `config.json` (in a run directory) as cwd-relative strings, not absolute paths. This makes building a model from the output `config.json` difficult without manual editing of the file. I'm trying to do the latter to access pre-calculated elastic kernels across a suite of models. 

This PR edits `cli.py`, converting CLI filenames from strings to absolute paths. 