### PR TITLE
Convert celeri-remove-vels-segment-collocated to argparse (fixes #491)

### DIFF
--- a/celeri/scripts/celeri_remove_vels_segment_collocated.py
+++ b/celeri/scripts/celeri_remove_vels_segment_collocated.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -9,17 +10,27 @@ from shapely.geometry import LineString, Point
 
 
 def main():
-    # Check if correct number of arguments provided
-    if len(sys.argv) < 3 or len(sys.argv) > 4:
-        print(
-            "Usage: python process_csv.py <station.csv> <segment.csv> [buffer_distance]"
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove GPS stations collocated with fault segments: find stations "
+            "within a buffer distance of any segment and write a filtered "
+            "station CSV."
         )
-        print("Default buffer distance: 0.002")
-        sys.exit(1)
+    )
+    parser.add_argument("station_file", type=str, help="Path to input station CSV file")
+    parser.add_argument("segment_file", type=str, help="Path to input segment CSV file")
+    parser.add_argument(
+        "--buffer-distance",
+        type=float,
+        default=0.002,
+        help="Buffer distance around each segment (default: 0.002)",
+    )
 
-    station_file = sys.argv[1]
-    segment_file = sys.argv[2]
-    buffer_distance = float(sys.argv[3]) if len(sys.argv) == 4 else 0.002
+    args = parser.parse_args()
+
+    station_file = args.station_file
+    segment_file = args.segment_file
+    buffer_distance = args.buffer_distance
 
     # Read CSV files into pandas dataframes
     try:


### PR DESCRIPTION
## Summary

`celeri-remove-vels-segment-collocated` (module `celeri.scripts.celeri_remove_vels_segment_collocated`) hand-parsed `sys.argv` instead of using `argparse` like every other `celeri-*` entry point. Two consequences:

1. **No working `--help`.** `--help` was treated as a positional arg; with fewer than 3 args, `main()` printed a usage string and `sys.exit(1)`, so the command exited non-zero on `--help` — unlike every other script.
2. **Stale usage text.** It printed `Usage: python process_csv.py ...`, a leftover from before this became a packaged console script.

This surfaced while packaging v0.0.6 for conda-forge, whose recipe smoke-tests every entry point with `--help`. This script was the sole outlier, so the feedstock had to special-case it with a module-import check (see conda-forge/celeri-feedstock#4).

## Change

Convert `main()` to `argparse` with positional `station_file`/`segment_file` arguments and an optional `--buffer-distance` (default `0.002`), matching the house style of the other scripts (e.g. `celeri_report_segment_priors.py`). `import sys` is retained (still used by `sys.exit(1)` in the CSV-read error handling); everything from the CSV-read `try:` block onward is unchanged.

This restores a working `--help` (exit 0) and lets the feedstock drop its workaround.

## Compatibility

The module is a leaf: nothing imports it, no test exercises it, and no CI/notebook/doc/shell invokes the command — the only reference is its entry-point line in `pyproject.toml`, which calls zero-arg `main()` (argparse reads `sys.argv` itself, so this keeps working). The `0.002` default preserves the output-filename convention (`{stem}_near_segment_removed_{buffer_distance}.csv`). The only intentional, depended-on-by-no-one changes: `--help` now exits 0, wrong args exit 2 with argparse usage, and the old optional 3rd positional becomes `--buffer-distance`.

## Verification

Run locally with `MPLBACKEND=Agg`:

- `celeri-remove-vels-segment-collocated --help` → prints argparse help with the correct program name, **exit 0** (was exit 1).
- Default run on `data/` WNA station/segment CSVs → writes `wna_station_near_segment_removed_0.002.csv`, removes 11 stations.
- `--buffer-distance 0.01` → writes `wna_station_near_segment_removed_0.01.csv`, removes 61 stations (larger buffer, as expected).
- No args → argparse usage + exit 2.
- `ruff check` and `ruff format --check` clean.

Fixes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)