### PR TITLE
Fail fast on malformed release tags in release-pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,21 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Validate release tag format
+        # hatch-vcs derives the package version from the git tag via
+        # tag-pattern='^v(\d+\.\d+\.\d+)$' (see pyproject.toml). A tag that doesn't
+        # match (e.g. `0.06`) otherwise fails deep inside the sdist build with a
+        # cryptic "Can't parse version from tag" ValueError. Fail fast, up front,
+        # with an actionable message instead.
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '${RELEASE_TAG}' is not of the form vX.Y.Z (e.g. v0.0.6). hatch-vcs cannot derive the package version from it. Delete this release/tag and re-cut it with a vX.Y.Z tag."
+            exit 1
+          fi
+          echo "Release tag '${RELEASE_TAG}' matches vX.Y.Z."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Problem

The `build-package` job in `release-pipeline` fails with a cryptic traceback when a release is cut with a tag that hatch-vcs can't parse. This actually happened on 2026-07-04: a release tagged `0.06` (instead of `v0.0.6`) failed with

```
ValueError: Error getting the version from source `vcs`:
  Can't parse version from tag '0.06' (tag_regex='^v(\d+\.\d+\.\d+)$', tag_prefix='')
```

buried deep inside `hatchling.build.build_sdist`. Nothing points the maintainer at the real cause — a mis-formatted tag.

## Change

Add an up-front `Validate release tag format` step to `build-package` that checks the release tag against the same `vX.Y.Z` shape hatch-vcs requires (`tag-pattern` in `pyproject.toml`) and fails immediately with an actionable message:

```
::error::Release tag '0.06' is not of the form vX.Y.Z (e.g. v0.0.6). hatch-vcs
cannot derive the package version from it. Delete this release/tag and re-cut it
with a vX.Y.Z tag.
```

The step is gated on `github.event_name == 'release'`, so the `push`/`pull_request` build+verify runs are unaffected. The regex was checked against `v0.0.6`, `v0.1.0` (accept) and `0.06`, `v1.2`, `v0.0.6-rc1`, `va.b.c` (reject), matching hatch-vcs's `^v(\d+\.\d+\.\d+)$`.

## Scope note

This intentionally does **not** touch the separate "file already exists on PyPI" failure mode (the `v0.0.5` re-publish 400). That one *should* fail loudly — a duplicate-version publish is a real error worth surfacing, not something to silently skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)