### PR TITLE
Add option to abort stuck chains

### DIFF
--- a/celeri/config.py
+++ b/celeri/config.py
@@ -232,6 +232,24 @@ class Config(RelativePathSerializerMixin, BaseModel):
     mcmc_backend: Literal["numba", "jax"] = "jax"
     """Backend to use for MCMC computations."""
 
+    mcmc_drop_stalled_chains: bool = False
+    """Abort and drop stalled MCMC chains once the other chains finish.
+
+    Once at least one chain has finished all its draws, a running chain is
+    considered stalled when the time-weighted median of its draw durations
+    (counting the time since its last completed draw) exceeds five times
+    the time-weighted 90th percentile of the slowest finished chain's
+    draw durations in the chain's current phase (warmup or sampling). When
+    only stalled chains are left running, sampling is aborted and the
+    estimation continues with the finished chains at their full draw
+    count; the dropped chains are recorded on
+    ``Estimation.mcmc_dropped_chains``. Note that a dropped chain may be
+    slow because it wandered into a difficult region of the posterior.
+    Intended for long multi-chain runs on non-interactive services where a
+    stalled chain would otherwise hold up the run indefinitely. ``False``
+    (the default) uses the plain blocking sampling call.
+    """
+
     mesh_default_eigenvector_algorithm: EigenvectorAlgorithm = "eigh"
     """Default algorithm for computing eigenvectors in mesh processing.
 

--- a/celeri/mcmc_watchdog.py
+++ b/celeri/mcmc_watchdog.py
@@ -1,0 +1,204 @@
+"""Watchdog for MCMC sampling that aborts and drops stalled chains.
+
+Enabled via ``Config.mcmc_drop_stalled_chains``; see
+:func:`sample_with_watchdog` for the stall rule.
+"""
+
+import time
+from typing import Any
+
+import numpy as np
+from loguru import logger
+
+STALL_FACTOR = 5.0
+"""A running chain is stalled when the time-weighted median of its draw
+durations exceeds this factor times the time-weighted 90th percentile of
+the slowest finished chain's draw durations."""
+
+POLL_SECONDS = 15.0
+
+
+def _weighted_quantile(observations: list[tuple[float, float]], q: float) -> float:
+    """Quantile of ``(value, weight)`` pairs, weighted by the second entry."""
+    if not observations:
+        return float("inf")
+    observations = sorted(observations)
+    total = sum(w for _, w in observations)
+    acc = 0.0
+    for value, weight in observations:
+        acc += weight
+        if acc >= q * total:
+            return value
+    return observations[-1][0]
+
+
+def _drop_unfinished_chains(trace: Any, progress: Any) -> tuple[Any, list[int]]:
+    """Drop the chains that had not finished when sampling was aborted.
+
+    ``sampler.abort()`` pads every chain to the longest chain's draw count
+    (NaN for floats, zeros for ints/bools), so finished chains keep all
+    their draws while unfinished chains end in padding. Completion is
+    judged from the returned trace itself, because a chain may finish
+    between the last progress snapshot and the abort taking effect; the
+    snapshot is used only for logging. The authoritative field is the
+    sampler-owned log-density ``sample_stats["logp"]``: nutpie writes one
+    finite value per completed draw and pads with NaN (verified on nutpie
+    0.16.10, where unfinished chains carry a contiguous NaN tail).
+    Derived posterior quantities can be legitimately non-finite on a valid
+    draw, so they must not be consulted. nutpie's chain coordinate is
+    ``arange(n_chains)``, so the returned labels are integers coinciding
+    with chain positions.
+    """
+    log_density = trace.sample_stats["logp"].values
+    keep, dropped = [], []
+    for i in range(log_density.shape[0]):
+        (dropped if np.isnan(log_density[i]).any() else keep).append(i)
+    if not dropped:
+        return trace, []
+    labels = [int(c) for c in np.asarray(trace.posterior.chain.values)[dropped]]
+    logger.warning(
+        f"Dropping unfinished chains {labels} and continuing with the "
+        f"{len(keep)} finished chains "
+        f"(finished draws/total draws/latest trajectory steps per chain: "
+        f"{[(c.finished_draws, c.total_draws, c.latest_num_steps) for c in progress]})."
+    )
+    if len(keep) == 1:
+        logger.warning(
+            "Only one chain was retained: between-chain convergence "
+            "diagnostics such as R-hat are unavailable for this run."
+        )
+    return trace.isel(chain=keep), labels
+
+
+def sample_with_watchdog(
+    compiled: Any, *, n_tune: int | None, **sample_kwargs: Any
+) -> tuple[Any, list[int]]:
+    """Sample with nutpie, aborting once only stalled chains are left running.
+
+    Uses nutpie's non-blocking API (``blocking=False`` plus a progress
+    callback) and polls ``sampler.wait``. A running chain is stalled when
+    the time-weighted median of its draw durations -- counting the time
+    since its last completed draw as a censored observation -- exceeds
+    ``STALL_FACTOR`` times the time-weighted 90th percentile of the
+    slowest finished chain's draw durations in the chain's current phase
+    (warmup or sampling), since warmup draws are systematically slower.
+    Durations are measured as per-poll batch means, so the quantiles are
+    approximate at the poll resolution.
+    Once at least one chain has finished and every unfinished chain is
+    stalled, sampling is aborted and the stalled chains are dropped, so
+    the estimation continues with the finished chains at their full draw
+    count.
+
+    Behavior pinned to nutpie 0.16.10: ``sampler.wait(timeout=...)``
+    raises ``TimeoutError`` while sampling is still running, and on
+    success consumes the results (so ``abort()`` is only called when
+    ``wait`` did not succeed); ``sampler.abort()`` returns a trace padded
+    to the longest chain, so finished chains keep every draw; the
+    progress callback receives ``list[ChainProgress]``, one entry per
+    chain, updated once per completed draw; each callback gets a freshly
+    cloned snapshot, never mutated afterwards, so the poll loop can read
+    it safely.
+
+    Returns:
+        ``(trace, dropped)`` where ``dropped`` lists the chain labels
+        removed from the trace (empty if sampling completed normally).
+    """
+    import nutpie
+
+    if n_tune is None:
+        raise ValueError(
+            "The stalled-chain watchdog needs an explicit warmup length to "
+            "compare warmup and sampling draws separately; set "
+            "config.mcmc_tune to an integer."
+        )
+    colliding = {"blocking", "progress_callback"} & sample_kwargs.keys()
+    if colliding:
+        raise ValueError(
+            f"The stalled-chain watchdog controls {sorted(colliding)}; "
+            f"remove them from sample_kwargs."
+        )
+
+    progress_holder: dict[str, Any] = {"chains": None}
+
+    def _progress_callback(chains: Any) -> None:
+        # Called by nutpie with list[ChainProgress], one entry per chain.
+        # Runs on a nutpie background thread; exceptions are swallowed.
+        progress_holder["chains"] = chains
+
+    sampler = nutpie.sample(
+        compiled,
+        blocking=False,
+        progress_callback=_progress_callback,
+        **sample_kwargs,
+    )
+
+    prev: dict[int, tuple[int, float]] = {}  # chain -> (draws, runtime seconds)
+    last_advance: dict[int, float] = {}  # chain -> time of last completed draw
+    # chain -> phase (True = warmup) -> [(mean draw duration, weight)]
+    durations: dict[int, dict[bool, list[tuple[float, float]]]] = {}
+
+    while True:
+        try:
+            return sampler.wait(timeout=POLL_SECONDS), []
+        except TimeoutError:
+            pass
+        chains = progress_holder["chains"]
+        if chains is None:
+            continue
+        now = time.monotonic()
+        for idx, c in enumerate(chains):
+            last_advance.setdefault(idx, now)
+            pf, pr = prev.get(idx, (0, 0.0))
+            runtime = c.runtime_ms / 1000.0
+            dd = c.finished_draws - pf
+            if dd <= 0:
+                continue
+            mean = (runtime - pr) / dd
+            phases = durations.setdefault(idx, {True: [], False: []})
+            # Draws numbered up to n_tune are warmup; a batch spanning the
+            # boundary contributes its mean to both phases.
+            n_warm = min(max(n_tune - pf, 0), dd)
+            if n_warm:
+                phases[True].append((mean, mean * n_warm))
+            if dd - n_warm:
+                phases[False].append((mean, mean * (dd - n_warm)))
+            prev[idx] = (c.finished_draws, runtime)
+            last_advance[idx] = now
+
+        finished = [
+            idx for idx, c in enumerate(chains) if c.finished_draws >= c.total_draws
+        ]
+        unfinished = [
+            idx for idx, c in enumerate(chains) if c.finished_draws < c.total_draws
+        ]
+        if not finished or not unfinished:
+            continue
+        # Anchor the threshold to the slowest finished chain (max of the
+        # per-chain p90s, not a pooled quantile): a chain within
+        # STALL_FACTOR of some chain that actually finished is not stuck.
+        p90 = {
+            phase: max(
+                _weighted_quantile(durations[idx][phase], 0.90) for idx in finished
+            )
+            for phase in (True, False)
+        }
+
+        stalled = []
+        for idx in unfinished:
+            # Judge each chain only by its current phase: history from a
+            # completed slow warmup must not condemn a healthy sampler.
+            in_warmup = chains[idx].finished_draws < n_tune
+            phases = durations.get(idx, {True: [], False: []})
+            silence = now - last_advance[idx]
+            observations = [*phases[in_warmup], (silence, silence)]
+            median = _weighted_quantile(observations, 0.50)
+            if median > STALL_FACTOR * p90[in_warmup]:
+                stalled.append(idx)
+        if stalled == unfinished:
+            logger.warning(
+                f"MCMC chains {stalled} are stalled (time-weighted median "
+                f"draw duration exceeds {STALL_FACTOR}x the finished "
+                f"chains' 90th percentile) and all other chains have "
+                f"finished; aborting sampling."
+            )
+            return _drop_unfinished_chains(sampler.abort(), chains)

--- a/celeri/solve.py
+++ b/celeri/solve.py
@@ -63,6 +63,12 @@ class Estimation:
     """Duration of MCMC sampling."""
     mcmc_num_divergences: int | None = None
     """Number of divergent transitions in MCMC sampling."""
+    mcmc_dropped_chains: list[int] | None = None
+    """Chain labels dropped by the stalled-chain watchdog.
+
+    ``None`` when the watchdog was not enabled; an empty list when it ran
+    and dropped nothing.
+    """
     celeri_version: str | None = None
     """Version of celeri used to create this estimation."""
 

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -34,6 +34,7 @@ from celeri._arviz_compat import (  # LEGACY-MCMC
 )
 from celeri.celeri_util import get_keep_index_12
 from celeri.constants import RADIUS_EARTH
+from celeri.mcmc_watchdog import sample_with_watchdog
 from celeri.model import Model
 from celeri.operators import (
     LosOperators,
@@ -1767,8 +1768,16 @@ def solve_mcmc(
     }
     kwargs.update(sample_kwargs or {})
 
+    dropped_chains: list[int] | None = None
     mcmc_start_time = datetime.now(UTC)
-    trace = nutpie.sample(compiled, **kwargs)  # type: ignore
+    if model.config.mcmc_drop_stalled_chains:
+        trace, dropped_chains = sample_with_watchdog(
+            compiled,
+            n_tune=kwargs["tune"],
+            **kwargs,
+        )
+    else:
+        trace = nutpie.sample(compiled, **kwargs)  # type: ignore
     mcmc_end_time = datetime.now(UTC)
     mcmc_duration = (mcmc_end_time - mcmc_start_time).total_seconds()
 
@@ -1791,6 +1800,7 @@ def solve_mcmc(
     estimation.mcmc_end_time = mcmc_end_time.isoformat()
     estimation.mcmc_duration = mcmc_duration
     estimation.mcmc_num_divergences = int(trace.sample_stats.diverging.sum())
+    estimation.mcmc_dropped_chains = dropped_chains
     return estimation
 
 

--- a/tests/test_mcmc_watchdog.py
+++ b/tests/test_mcmc_watchdog.py
@@ -1,0 +1,402 @@
+"""Tests for the stalled-chain MCMC watchdog."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from celeri.mcmc_watchdog import (
+    _drop_unfinished_chains,
+    _weighted_quantile,
+    sample_with_watchdog,
+)
+
+
+def _chain_progress(finished_per_chain, total=100):
+    return [
+        SimpleNamespace(finished_draws=n, total_draws=total, latest_num_steps=7)
+        for n in finished_per_chain
+    ]
+
+
+def _make_aborted_trace(
+    valid_per_chain: list[int], n_draws: int, derived_nan: bool = False
+):
+    """Build a synthetic aborted trace with nutpie-style padding.
+
+    Each chain has ``valid_per_chain[i]`` valid draws followed by padding:
+    NaN for floats, False for bools, mimicking what nutpie's ``abort()``
+    returns. With ``derived_nan``, a derived posterior variable carries a
+    legitimate NaN inside chain 0's valid draws. Returns an
+    ``xarray.DataTree`` on ArviZ>=1 and an ``arviz.InferenceData`` on
+    ArviZ<1.
+    """
+    import arviz as az
+
+    n_chains = len(valid_per_chain)
+    x = np.full((n_chains, n_draws), np.nan)
+    logp = np.full((n_chains, n_draws), np.nan)
+    for i, n_valid in enumerate(valid_per_chain):
+        x[i, :n_valid] = 1.0
+        logp[i, :n_valid] = -100.0
+    posterior = {"x": x}
+    if derived_nan:
+        derived = x.copy()
+        derived[0, min(5, n_draws - 1)] = np.nan
+        posterior["derived"] = derived
+    groups = {
+        "posterior": posterior,
+        "sample_stats": {
+            "logp": logp,
+            "diverging": np.zeros((n_chains, n_draws), dtype=bool),
+        },
+    }
+    coords = {"chain": np.arange(n_chains), "draw": np.arange(n_draws)}
+
+    # LEGACY-MCMC: ArviZ<1's ``from_dict`` takes groups as keyword arguments;
+    # ArviZ>=1's takes a single mapping of group name -> variables.
+    # (``from_datatree`` only exists on ArviZ<1, so it flags the legacy
+    # stack.) On cleanup, keep only the ArviZ>=1 branch below.
+    if hasattr(az, "from_datatree"):
+        return az.from_dict(**groups, coords=coords)
+    return az.from_dict(groups, coords=coords)
+
+
+class TestDropUnfinishedChains:
+    """Verify post-abort recovery drops padded chains, keeps finished ones."""
+
+    def test_keeps_finished_chains_at_full_length(self):
+        # Chains 0 and 2 finished; chains 1 and 3 are stuck stragglers.
+        trace = _make_aborted_trace([100, 30, 100, 0], n_draws=100)
+        progress = _chain_progress([200, 130, 200, 0], total=200)
+        reduced, dropped = _drop_unfinished_chains(trace, progress)
+        assert dropped == [1, 3]
+        assert list(reduced.posterior.chain.values) == [0, 2]
+        assert reduced.posterior.sizes["draw"] == 100
+        assert np.isfinite(reduced.posterior["x"].values).all()
+        assert np.isfinite(reduced.sample_stats["logp"].values).all()
+
+    def test_keeps_chain_that_finished_during_abort(self):
+        # The progress snapshot predates abort() and says chain 1 was at
+        # 130 of 200 draws, but the returned trace shows it complete: the
+        # trace is authoritative, so nothing is dropped.
+        trace = _make_aborted_trace([100, 100], n_draws=100)
+        progress = _chain_progress([200, 130], total=200)
+        reduced, dropped = _drop_unfinished_chains(trace, progress)
+        assert dropped == []
+        assert reduced.posterior.sizes["chain"] == 2
+
+    def test_non_finite_derived_posterior_is_not_padding(self):
+        # Chain 0 finished but a derived posterior variable holds a
+        # legitimate NaN within its valid draws. Completion is judged from
+        # the sampler-owned log-density, so chain 0 must be retained and
+        # only the genuinely unfinished chain 1 dropped.
+        trace = _make_aborted_trace([100, 50], n_draws=100, derived_nan=True)
+        progress = _chain_progress([200, 150], total=200)
+        reduced, dropped = _drop_unfinished_chains(trace, progress)
+        assert dropped == [1]
+        assert list(reduced.posterior.chain.values) == [0]
+
+    def test_all_finished_is_a_no_op(self):
+        trace = _make_aborted_trace([100, 100], n_draws=100)
+        progress = _chain_progress([200, 200], total=200)
+        reduced, dropped = _drop_unfinished_chains(trace, progress)
+        assert dropped == []
+        assert reduced.posterior.sizes["chain"] == 2
+
+
+class TestWeightedQuantile:
+    def test_unweighted_median(self):
+        assert _weighted_quantile([(1.0, 1.0), (2.0, 1.0), (3.0, 1.0)], 0.50) == 2.0
+
+    def test_time_weighting_favors_long_draws(self):
+        obs = [(1.0, 1.0)] * 9 + [(10.0, 10.0)]
+        assert _weighted_quantile(obs, 0.50) == 10.0
+
+    def test_empty_is_infinite(self):
+        assert _weighted_quantile([], 0.50) == float("inf")
+
+
+def _snap(finished_per_chain, runtime_s_per_chain, total=100):
+    """One progress snapshot: per-chain (finished draws, cumulative seconds)."""
+    return [
+        SimpleNamespace(
+            finished_draws=f,
+            total_draws=total,
+            runtime_ms=r * 1000.0,
+            latest_num_steps=7,
+        )
+        for f, r in zip(finished_per_chain, runtime_s_per_chain, strict=True)
+    ]
+
+
+class _FakeSampler:
+    """Stand-in for nutpie's non-blocking sampler.
+
+    Mimics the nutpie 0.16.10 semantics the watchdog relies on: ``wait``
+    raises ``TimeoutError`` until sampling completes, and ``abort``
+    returns the (padded) trace. Each ``wait`` advances the fake clock by
+    its timeout and plays the next snapshot of the progress script (the
+    last entry repeats; ``None`` means sampling completed).
+    """
+
+    def __init__(self, progress_callback, progress_script, result, clock):
+        self._progress_callback = progress_callback
+        self._progress_script = progress_script
+        self._result = result
+        self._clock = clock
+        self._calls = 0
+        self.aborted = False
+
+    def wait(self, timeout=None):
+        self._clock.now += timeout
+        progress = self._progress_script[
+            min(self._calls, len(self._progress_script) - 1)
+        ]
+        self._calls += 1
+        if progress is None:  # sampling complete
+            return self._result
+        self._progress_callback(progress)
+        raise TimeoutError
+
+    def abort(self):
+        self.aborted = True
+        return self._result
+
+
+class TestSampleWithWatchdog:
+    """Verify the watchdog poll loop against a fake non-blocking sampler.
+
+    All scenarios use total_draws=100 with n_tune=20 and a fake clock
+    advancing 1 s per poll. Healthy draws take 1 s; the stall threshold is
+    therefore 5 s (``STALL_FACTOR`` times the finished chain's p90).
+    """
+
+    N_TUNE = 20
+
+    def _run(self, monkeypatch, progress_script, result):
+        import nutpie
+
+        from celeri import mcmc_watchdog
+
+        clock = SimpleNamespace(now=0.0)
+        samplers = []
+
+        def fake_sample(compiled, *, blocking, progress_callback, **kwargs):
+            assert blocking is False
+            sampler = _FakeSampler(progress_callback, progress_script, result, clock)
+            samplers.append(sampler)
+            return sampler
+
+        monkeypatch.setattr(nutpie, "sample", fake_sample)
+        monkeypatch.setattr(mcmc_watchdog, "POLL_SECONDS", 1.0)
+        monkeypatch.setattr(
+            mcmc_watchdog, "time", SimpleNamespace(monotonic=lambda: clock.now)
+        )
+        trace, dropped = sample_with_watchdog("compiled", n_tune=self.N_TUNE)
+        return trace, dropped, samplers[0]
+
+    def test_returns_trace_on_completion(self, monkeypatch):
+        script = [_snap([50, 60], [50.0, 60.0]), None]
+        trace, dropped, sampler = self._run(monkeypatch, script, "trace")
+        assert trace == "trace"
+        assert dropped == []
+        assert not sampler.aborted
+
+    def test_aborts_dead_chain(self, monkeypatch):
+        # Chains 0 and 2 finished; chain 1 froze at 50 of 100 draws. Its
+        # growing silence eventually dominates its time-weighted median.
+        result = _make_aborted_trace([100, 50, 100], n_draws=100)
+        script = [_snap([100, 50, 100], [100.0, 50.0, 100.0])]
+        trace, dropped, sampler = self._run(monkeypatch, script, result)
+        assert sampler.aborted
+        assert dropped == [1]
+        assert list(trace.posterior.chain.values) == [0, 2]
+        assert trace.posterior.sizes["draw"] == 100
+        assert np.isfinite(trace.posterior["x"].values).all()
+
+    def test_no_abort_while_no_chain_finished(self, monkeypatch):
+        # All chains frozen but none finished: the watchdog must not fire
+        # (there is nothing to continue with); completion returns the trace.
+        frozen = _snap([50, 50], [50.0, 50.0])
+        script = [frozen] * 200 + [None]
+        trace, dropped, sampler = self._run(monkeypatch, script, "trace")
+        assert trace == "trace"
+        assert dropped == []
+        assert not sampler.aborted
+
+    def test_keeps_slow_but_alive_chain(self, monkeypatch):
+        # Chain 1 advances steadily at 3 s per draw (3x the finished
+        # chain's pace, below the 5x threshold): never dropped.
+        script = [_snap([100, 50 + i], [100.0, 3.0 * (50 + i)]) for i in range(40)]
+        script.append(None)
+        trace, dropped, sampler = self._run(monkeypatch, script, "trace")
+        assert trace == "trace"
+        assert dropped == []
+        assert not sampler.aborted
+
+    def test_drops_pathologically_slow_chain(self, monkeypatch):
+        # Chain 1 keeps completing draws, but at 20 s each: a fixed
+        # no-progress timeout would never fire on it.
+        result = _make_aborted_trace([100, 50], n_draws=100)
+        script = [_snap([100, 50 + i], [100.0, 20.0 * (50 + i)]) for i in range(50)]
+        _trace, dropped, sampler = self._run(monkeypatch, script, result)
+        assert sampler.aborted
+        assert dropped == [1]
+
+    def test_warmup_pace_is_judged_against_warmup(self, monkeypatch):
+        # Warmup draws run 3x slower for everyone: the finished chain does
+        # 20 warmup draws at 3 s, then 80 sampling draws at 1 s (snapshots
+        # split at the boundary so each phase gets its own reference).
+        # Chain 1 crawls through warmup at 8 s per draw: slow, but under
+        # 5x the 3 s warmup p90, so it survives.
+        script = [_snap([20, 5], [60.0, 40.0])]
+        script += [_snap([100, 5 + i], [140.0, 8.0 * (5 + i)]) for i in range(1, 10)]
+        script.append(None)
+        trace, dropped, sampler = self._run(monkeypatch, script, "trace")
+        assert trace == "trace"
+        assert dropped == []
+        assert not sampler.aborted
+
+    def test_sampling_pace_is_judged_against_sampling(self, monkeypatch):
+        # Same finished chain as above. Chain 1 is past warmup and draws at
+        # 8 s: over 5x the 1 s sampling p90, so it is dropped -- even though
+        # it would look acceptable against a pooled reference diluted by
+        # the slow warmup draws (pooled p90 is 3 s, threshold 15 s).
+        result = _make_aborted_trace([100, 50], n_draws=100)
+        script = [_snap([20, 20], [60.0, 60.0])]
+        script += [
+            _snap([100, 50 + i], [140.0, 60.0 + 8.0 * (30 + i)]) for i in range(50)
+        ]
+        _trace, dropped, sampler = self._run(monkeypatch, script, result)
+        assert sampler.aborted
+        assert dropped == [1]
+
+    def test_drops_chain_that_never_started(self, monkeypatch):
+        # Chain 1 never completes a single draw: only its censored silence
+        # is observable, and it alone eventually exceeds the threshold.
+        result = _make_aborted_trace([100, 0], n_draws=100)
+        script = [_snap([100, 0], [120.0, 0.0])]
+        _trace, dropped, sampler = self._run(monkeypatch, script, result)
+        assert sampler.aborted
+        assert dropped == [1]
+
+    def test_chain_finishing_during_abort_is_kept(self, monkeypatch):
+        # The last snapshot shows chain 1 frozen at 50 draws, so the
+        # watchdog aborts -- but the trace returned by abort() shows the
+        # chain actually finished in the meantime. It must be kept.
+        result = _make_aborted_trace([100, 100], n_draws=100)
+        script = [_snap([100, 50], [100.0, 50.0])]
+        trace, dropped, sampler = self._run(monkeypatch, script, result)
+        assert sampler.aborted
+        assert dropped == []
+        assert trace.posterior.sizes["chain"] == 2
+
+    def test_slow_warmup_history_does_not_condemn_healthy_sampler(self, monkeypatch):
+        # Chain 1 crawled through warmup at 20 s per draw (well over 5x the
+        # 3 s warmup p90) but now samples at a healthy 1 s: only its current
+        # phase counts, so it must not be dropped.
+        script = [_snap([20, 5], [60.0, 100.0])]
+        script.append(_snap([100, 20], [140.0, 400.0]))
+        script += [_snap([100, 20 + i], [140.0, 400.0 + 1.0 * i]) for i in range(1, 30)]
+        script.append(None)
+        trace, dropped, sampler = self._run(monkeypatch, script, "trace")
+        assert trace == "trace"
+        assert dropped == []
+        assert not sampler.aborted
+
+    def test_rejects_missing_n_tune(self):
+        with pytest.raises(ValueError, match="warmup length"):
+            sample_with_watchdog("compiled", n_tune=None)
+
+    def test_rejects_colliding_sample_kwargs(self):
+        with pytest.raises(ValueError, match="blocking"):
+            sample_with_watchdog("compiled", n_tune=20, blocking=True)
+
+
+class TestLiveDoubleWell:
+    """End-to-end run against real nutpie, no fakes.
+
+    The target is a double-well potential in x0 (wells at +-3, ~40-nat
+    barrier, so chains never cross), and the logp function sleeps 2 ms per
+    evaluation whenever x0 > 0. Chains seeded into the positive well
+    therefore sample correctly but ~two orders of magnitude too slowly --
+    the failure mode a fixed no-progress timeout can never catch.
+    """
+
+    def test_drops_genuinely_slow_chains(self, monkeypatch):
+        import itertools
+        import threading
+        import time
+
+        from nutpie.compiled_pyfunc import from_pyfunc
+
+        from celeri import mcmc_watchdog
+
+        monkeypatch.setattr(mcmc_watchdog, "POLL_SECONDS", 0.2)
+
+        ndim, barrier_k, sleep_s = 4, 0.5, 0.002
+
+        def make_logp_fn():
+            def logp(x):
+                x0, rest = x[0], x[1:]
+                if x0 > 0:
+                    time.sleep(sleep_s)
+                value = -barrier_k * (x0**2 - 9.0) ** 2 - 0.5 * np.sum(rest**2)
+                grad = np.empty_like(x)
+                grad[0] = -4.0 * barrier_k * x0 * (x0**2 - 9.0)
+                grad[1:] = -rest
+                return value, grad
+
+            return logp
+
+        def make_expand_fn(seed1, seed2, chain):
+            def expand(x):
+                return {"x": x.copy()}
+
+            return expand
+
+        counter = itertools.count()
+        lock = threading.Lock()
+
+        def initial_point(seed):
+            # Deal chains alternately into the two wells. Init calls run in
+            # thread order, so which chain ids are slow varies; exactly half
+            # must be dropped. The well floor has zero gradient, which
+            # nutpie rejects as an initial point, hence the jitter.
+            with lock:
+                i = next(counter)
+            rng = np.random.default_rng(seed)
+            point = 0.2 * rng.normal(size=ndim)
+            point[0] += 3.0 if i % 2 else -3.0
+            return point
+
+        compiled = from_pyfunc(
+            ndim=ndim,
+            make_logp_fn=make_logp_fn,
+            make_expand_fn=make_expand_fn,
+            expanded_dtypes=[np.dtype("float64")],
+            expanded_shapes=[(ndim,)],
+            expanded_names=["x"],
+            make_initial_point_fn=initial_point,
+        )
+
+        tune, draws = 400, 800
+        trace, dropped = sample_with_watchdog(
+            compiled,
+            n_tune=tune,
+            tune=tune,
+            draws=draws,
+            chains=6,
+            cores=6,
+            seed=0,
+            progress_bar=False,
+        )
+
+        post = trace.posterior
+        assert len(dropped) == 3, f"expected the 3 slow chains dropped: {dropped}"
+        assert post.sizes["chain"] == 3
+        assert post.sizes["draw"] == draws
+        assert np.isfinite(post["x"].values).all()
+        x0_means = post["x"].values[..., 0].mean(axis=1)
+        assert (x0_means < -2.5).all(), "kept chains must be in the fast well"


### PR DESCRIPTION
An implementation of @aseyboldt idea to use nutpie's non-blocking sampler to detect and abort stuck chains when the user sets `mcmc_drop_stalled_chains = True`.

I added an arguably over-engineered heuristic allowing the watchdog to immediately abort once all non-stuck chains have finished, so that you don't have to wait for any arbitrary thresholds. (A chain is considered stuck if another chain has completed, and the pending chain's time-weighted median step duration is 5x slower than the completed chain's 90th percentile.)