### PR TITLE
Update Pixi platform schema

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,12 @@
 
 [workspace]
 name = "celeri"
-platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+platforms = [
+    "linux-64",
+    { platform = "osx-64", macos = "13.3" },
+    { platform = "osx-arm64", macos = "13.3" },
+    "win-64",
+]
 channels = ["conda-forge"]
 
 [activation.env]
@@ -112,6 +117,3 @@ scikit-learn-stubs = ">=0.0.3"
 [environments]
 default = ["dev"]
 legacy-mcmc = ["dev", "legacy-mcmc"]  # LEGACY-MCMC: delete on cleanup
-
-[system-requirements]
-macos = "13.3"


### PR DESCRIPTION
## Summary

- move the macOS 13.3 virtual-package requirement from the deprecated
  `[system-requirements]` table to the `osx-64` and `osx-arm64` platform entries
- preserve the existing Linux, macOS, and Windows platform coverage
- leave `pixi.lock` unchanged because the migration is semantically equivalent

## Why

Pixi 0.72 deprecates workspace-level system requirements in favor of declaring
virtual packages directly on rich platform entries. The old schema still parses
for compatibility but emits a warning.

## Impact

The manifest no longer emits the deprecation warning with current Pixi. Both
macOS targets continue to resolve with macOS 13.3 as their minimum virtual
package, with no dependency-resolution changes.

## Validation

- `pixi 0.72.2 workspace platform list --manifest-path pixi.toml`
- `pixi 0.72.2 lock --manifest-path pixi.toml --check`
- repository commit hooks
