### PR TITLE
Enforce CCW circulation in segmesh

### DIFF
--- a/celeri/scripts/segmesh.py
+++ b/celeri/scripts/segmesh.py
@@ -342,7 +342,17 @@ def main():
             filename = mesh_dir / f"{seg_file_stem}_segmesh{mesh_idx}.msh"
 
             # Combined coordinates making a continuous perimeter loop
-            all_coords = np.vstack((top_coords, np.flipud(bottom_coords)))
+            # Check here for circulation direction. We want a positive z-component for the cross product of corners
+            vec1 = top_coords[-1, :] - top_coords[0, :]
+            vec2 = bottom_coords[-1, :] - top_coords[-1, :]
+            normal_vector = np.cross(vec1, vec2)
+            if (
+                normal_vector[2] < -1e-10
+            ):  # Negative cross-product; we're not worried about vertical faults
+                print("neg circulation")
+                all_coords = np.vstack((np.flipud(top_coords), bottom_coords))
+            else:
+                all_coords = np.vstack((top_coords, np.flipud(bottom_coords)))
             # Number of geometric objects
             n_coords = np.shape(all_coords)[0]
             n_surf = int((n_coords - 2) / 2)

--- a/celeri/scripts/segmesh.py
+++ b/celeri/scripts/segmesh.py
@@ -349,7 +349,7 @@ def main():
             if (
                 normal_vector[2] < -1e-10
             ):  # Negative cross-product; we're not worried about vertical faults
-                print("neg circulation")
+                print(f"Perimeter circulation corrected for *_segmesh{mesh_idx}")
                 all_coords = np.vstack((np.flipud(top_coords), bottom_coords))
             else:
                 all_coords = np.vstack((top_coords, np.flipud(bottom_coords)))


### PR DESCRIPTION
The sign conventions used in `celeri` assume counterclockwise node ordering for meshes (especially the finicky projection of relative block motion onto triangle geometries to yield slip rates). When meshing faults using `segmesh.py`, this ordering may be reversed, depending on how the ordered block coordinates are circulated. This has an impact on the sign of reported dip-slip kinematic rates, and therefore it may force slip deficit rates to adopt that same sign if dip-slip coupling constraints are applied. 

This only impacts dipping meshes, and it may not impact every dipping fault; it depends on the ordering of the segment coordinates used to create the mesh. But in previously generated segmeshes, elements that are ordered clockwise, the output sign of kinematic dip-slip is backwards, and for affected faults with coupling constraints, the output sign of the dip-slip deficit is also backwards. 

My initial test suggests that this has negligible impact on the model fit, because the sign of kinematic and elastic dip-slip are impacted equally, and therefore coupling constraints should be correctly imposed/satisfied. `cutde` is, I believe, working just fine, as it's essentially using the "bottom" face of clockwise elements rather than the conventional "top" for counterclockwise elements.   

Running this version of `segmesh.py` will print a report which faults get their circulation corrected (to be CCW). The correction is applied to the segment perimeter coordinates, which propagates into the circulation of the derived elements. 