### PR TITLE
Make MCMC mesh and segment outputs report posterior means consistently

### DIFF
--- a/celeri/output.py
+++ b/celeri/output.py
@@ -113,56 +113,31 @@ def write_output(
                 data=1,  # type: ignore[arg-type]
             )
 
-            if estimation.tde_rates is not None:
-                tde_ss_rates = estimation.tde_strike_slip_rates
-                tde_ds_rates = estimation.tde_dip_slip_rates
-                if tde_ss_rates is not None and tde_ds_rates is not None:
-                    grp.create_dataset(
-                        f"/meshes/mesh_{i:05}/strike_slip/{0:012}",
-                        data=tde_ss_rates[i],
-                    )
-                    grp.create_dataset(
-                        f"/meshes/mesh_{i:05}/dip_slip/{0:012}",
-                        data=tde_ds_rates[i],
-                    )
-                    grp.create_dataset(
-                        f"/meshes/mesh_{i:05}/tensile_slip/{0:012}",
-                        data=np.zeros_like(tde_ds_rates[i]),
-                    )
-
-                tde_ss_kinematic = estimation.tde_strike_slip_rates_kinematic
-                tde_ds_kinematic = estimation.tde_dip_slip_rates_kinematic
-                if tde_ss_kinematic is not None and tde_ds_kinematic is not None:
-                    if i in tde_ss_kinematic and i in tde_ds_kinematic:
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/strike_slip_kinematic/{0:012}",
-                            data=tde_ss_kinematic[i],
-                        )
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/dip_slip_kinematic/{0:012}",
-                            data=tde_ds_kinematic[i],
-                        )
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/tensile_slip_kinematic/{0:012}",
-                            data=np.zeros_like(tde_ds_kinematic[i]),
-                        )
-
-                coupling_ss = estimation.tde_strike_slip_rates_coupling
-                coupling_ds = estimation.tde_dip_slip_rates_coupling
-                if coupling_ss is not None and coupling_ds is not None:
-                    if i in coupling_ss and i in coupling_ds:
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/strike_slip_coupling/{0:012}",
-                            data=coupling_ss[i],
-                        )
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/dip_slip_coupling/{0:012}",
-                            data=coupling_ds[i],
-                        )
-                        grp.create_dataset(
-                            f"/meshes/mesh_{i:05}/tensile_slip_coupling/{0:012}",
-                            data=np.zeros_like(coupling_ds[i]),
-                        )
+            # Slip fields are the same arrays that go into model_meshes.csv
+            # (see Estimation.mesh_slip_fields); fields that are not defined
+            # for this mesh are omitted.
+            slip_fields = estimation.mesh_slip_fields(i)
+            for suffix, strike_slip_key, dip_slip_key in (
+                ("", "strike_slip_rate", "dip_slip_rate"),
+                ("_kinematic", "strike_slip_rate_kinematic", "dip_slip_rate_kinematic"),
+                ("_coupling", "strike_slip_coupling", "dip_slip_coupling"),
+            ):
+                strike_slip = slip_fields[strike_slip_key]
+                dip_slip = slip_fields[dip_slip_key]
+                if strike_slip is None or dip_slip is None:
+                    continue
+                grp.create_dataset(
+                    f"/meshes/mesh_{i:05}/strike_slip{suffix}/{0:012}",
+                    data=strike_slip,
+                )
+                grp.create_dataset(
+                    f"/meshes/mesh_{i:05}/dip_slip{suffix}/{0:012}",
+                    data=dip_slip,
+                )
+                grp.create_dataset(
+                    f"/meshes/mesh_{i:05}/tensile_slip{suffix}/{0:012}",
+                    data=np.zeros_like(dip_slip),
+                )
 
         # Try saving segment rate data in parsli style
         hdf.create_dataset(

--- a/celeri/solve.py
+++ b/celeri/solve.py
@@ -164,69 +164,124 @@ class Estimation:
         return mogi
 
     @cached_property
+    def _mcmc_posterior_mean(self):
+        """The MCMC posterior averaged over whatever sample dimensions it has."""
+        assert self.mcmc_trace is not None
+        posterior = self.mcmc_trace.posterior
+        sample_dims = [dim for dim in ("chain", "draw") if dim in posterior.dims]
+        return posterior.mean(sample_dims) if sample_dims else posterior
+
+    def mesh_slip_fields(self, mesh_idx: int) -> dict[str, np.ndarray | None]:
+        """The estimated slip fields of one mesh, as written to the output files.
+
+        Returns the elastic slip rates, kinematic slip rates and couplings for
+        strike slip and dip slip on mesh ``mesh_idx``. An entry is ``None``
+        when it is not defined for this estimation (no TDEs, or kinematic
+        rates for a mesh that is not tied to any segment). Both
+        ``mesh_estimate`` (``model_meshes.csv``) and the HDF5 writer read
+        from here so that the two outputs agree.
+
+        For MCMC estimations the elastic rates and couplings are the
+        posterior means of the sampled ``elastic_*`` and ``coupling_*``
+        fields, and the kinematic rates are the unsmoothed rates the sampler
+        used, evaluated at the posterior mean rotation (which is the
+        posterior mean kinematic rate, since the map is linear). Note that
+        ``tde_strike_slip_rates``/``tde_dip_slip_rates`` differ from these
+        for MCMC: they hold the projection of the posterior mean elastic
+        field onto the truncated eigenmode basis, i.e. the part of the field
+        that the sampler's forward model sees. When coupling was not sampled
+        (elastic-mode meshes) the coupling is the ratio elastic / kinematic.
+
+        For other solvers the elastic rates come from the state vector, the
+        kinematic rates are Gaussian smoothed when eigenmodes are in use,
+        and the coupling is the ratio elastic / kinematic.
+        """
+        fields: dict[str, np.ndarray | None] = {
+            "strike_slip_rate": None,
+            "dip_slip_rate": None,
+            "strike_slip_rate_kinematic": None,
+            "dip_slip_rate_kinematic": None,
+            "strike_slip_coupling": None,
+            "dip_slip_coupling": None,
+        }
+        if self.operators.tde is None:
+            return fields
+        strike_slip_rates = self.tde_strike_slip_rates
+        dip_slip_rates = self.tde_dip_slip_rates
+        if strike_slip_rates is None or dip_slip_rates is None:
+            return fields
+        fields["strike_slip_rate"] = strike_slip_rates[mesh_idx]
+        fields["dip_slip_rate"] = dip_slip_rates[mesh_idx]
+
+        if self.mcmc_trace is not None:
+            posterior_mean = self._mcmc_posterior_mean
+            kinematic = self.tde_kinematic.get(mesh_idx, None)
+            for kind, key, component in (
+                ("ss", "strike_slip", 0),
+                ("ds", "dip_slip", 1),
+            ):
+                elastic_var = f"elastic_{mesh_idx}_{kind}"
+                if elastic_var in posterior_mean:
+                    fields[f"{key}_rate"] = np.asarray(
+                        posterior_mean[elastic_var].values, dtype=float
+                    )
+                if kinematic is not None:
+                    fields[f"{key}_rate_kinematic"] = kinematic[component::2]
+                coupling_var = f"coupling_{mesh_idx}_{kind}"
+                if coupling_var in posterior_mean:
+                    fields[f"{key}_coupling"] = np.asarray(
+                        posterior_mean[coupling_var].values, dtype=float
+                    )
+                elif kinematic is not None:
+                    rate = fields[f"{key}_rate"]
+                    assert rate is not None
+                    with np.errstate(divide="ignore", invalid="ignore"):
+                        fields[f"{key}_coupling"] = rate / kinematic[component::2]
+            return fields
+
+        if self.operators.eigen is not None:
+            fields["strike_slip_rate_kinematic"] = (
+                self.tde_strike_slip_rates_kinematic_smooth.get(mesh_idx, None)
+            )
+            fields["dip_slip_rate_kinematic"] = (
+                self.tde_dip_slip_rates_kinematic_smooth.get(mesh_idx, None)
+            )
+            if (coupling := self.tde_strike_slip_rates_coupling_smooth) is not None:
+                fields["strike_slip_coupling"] = coupling.get(mesh_idx, None)
+            if (coupling := self.tde_dip_slip_rates_coupling_smooth) is not None:
+                fields["dip_slip_coupling"] = coupling.get(mesh_idx, None)
+        else:
+            fields["strike_slip_rate_kinematic"] = (
+                self.tde_strike_slip_rates_kinematic.get(mesh_idx, None)
+            )
+            fields["dip_slip_rate_kinematic"] = self.tde_dip_slip_rates_kinematic.get(
+                mesh_idx, None
+            )
+            if (coupling := self.tde_strike_slip_rates_coupling) is not None:
+                fields["strike_slip_coupling"] = coupling.get(mesh_idx, None)
+            if (coupling := self.tde_dip_slip_rates_coupling) is not None:
+                fields["dip_slip_coupling"] = coupling.get(mesh_idx, None)
+        return fields
+
+    @cached_property
     def mesh_estimate(self) -> pd.DataFrame | None:
-        """A dataframe containing the estimated slip rates and couplings for each mesh."""
+        """A dataframe containing the estimated slip rates and couplings for each mesh.
+
+        The slip columns come from `mesh_slip_fields`; fields that are not
+        defined for a mesh are written as zeros.
+        """
         if self.operators.tde is None:
             return None
         if self.tde_strike_slip_rates is None or self.tde_dip_slip_rates is None:
             return None
         meshes = self.model.meshes
         mesh_outputs_list: list[pd.DataFrame] = []
-        use_smooth = self.operators.eigen is not None
-        use_mcmc_coupling = self.mcmc_trace is not None
         for i in range(len(meshes)):
-            if use_smooth:
-                strike_slip_rate_kinematic = (
-                    self.tde_strike_slip_rates_kinematic_smooth.get(i, None)
-                )
-                dip_slip_rate_kinematic = self.tde_dip_slip_rates_kinematic_smooth.get(
-                    i, None
-                )
-            else:
-                strike_slip_rate_kinematic = self.tde_strike_slip_rates_kinematic.get(
-                    i, None
-                )
-                dip_slip_rate_kinematic = self.tde_dip_slip_rates_kinematic.get(i, None)
-
-            strike_slip_coupling = None
-            dip_slip_coupling = None
-
-            if use_mcmc_coupling:
-                trace_mean = self.mcmc_trace.posterior.mean(["chain", "draw"])  # type: ignore
-                ss_var = f"coupling_{i}_ss"
-                ds_var = f"coupling_{i}_ds"
-                if ss_var in trace_mean:
-                    strike_slip_coupling = trace_mean[ss_var].values
-                if ds_var in trace_mean:
-                    dip_slip_coupling = trace_mean[ds_var].values
-            elif use_smooth:
-                if self.tde_strike_slip_rates_coupling_smooth is not None:
-                    strike_slip_coupling = (
-                        self.tde_strike_slip_rates_coupling_smooth.get(i, None)
-                    )
-                if self.tde_dip_slip_rates_coupling_smooth is not None:
-                    dip_slip_coupling = self.tde_dip_slip_rates_coupling_smooth.get(
-                        i, None
-                    )
-            else:
-                if self.tde_strike_slip_rates_coupling is not None:
-                    strike_slip_coupling = self.tde_strike_slip_rates_coupling.get(
-                        i, None
-                    )
-                if self.tde_dip_slip_rates_coupling is not None:
-                    dip_slip_coupling = self.tde_dip_slip_rates_coupling.get(i, None)
-
-            # Create arrays of zeros with appropriate length if values are None
             n_elements = len(meshes[i].lon1)
-            if strike_slip_rate_kinematic is None:
-                strike_slip_rate_kinematic = np.zeros(n_elements)
-            if dip_slip_rate_kinematic is None:
-                dip_slip_rate_kinematic = np.zeros(n_elements)
-            if strike_slip_coupling is None:
-                strike_slip_coupling = np.zeros(n_elements)
-            if dip_slip_coupling is None:
-                dip_slip_coupling = np.zeros(n_elements)
-
+            slip_fields = {
+                key: np.zeros(n_elements) if value is None else value
+                for key, value in self.mesh_slip_fields(i).items()
+            }
             this_mesh_data = {
                 "lon1": meshes[i].lon1,
                 "lat1": meshes[i].lat1,
@@ -238,12 +293,7 @@ class Estimation:
                 "lat3": meshes[i].lat3,
                 "dep3": meshes[i].dep3,
                 "mesh_idx": i * np.ones_like(meshes[i].lon1).astype(int),
-                "strike_slip_rate": self.tde_strike_slip_rates[i],
-                "dip_slip_rate": self.tde_dip_slip_rates[i],
-                "strike_slip_rate_kinematic": strike_slip_rate_kinematic,
-                "dip_slip_rate_kinematic": dip_slip_rate_kinematic,
-                "strike_slip_coupling": strike_slip_coupling,
-                "dip_slip_coupling": dip_slip_coupling,
+                **slip_fields,
             }
 
             mesh_outputs_list.append(pd.DataFrame(this_mesh_data))
@@ -318,7 +368,12 @@ class Estimation:
 
     @cached_property
     def slip_rate_sigma(self) -> np.ndarray | None:
-        """The standard deviation of the estimated strike, dip, and tensile slip rates for each segment; propagated from `self.state_covariance_matrix`. Shape: (3 * n_segments,)."""
+        """The standard deviation of the estimated strike, dip, and tensile slip rates for each segment. Shape: (3 * n_segments,).
+
+        Propagated from `self.state_covariance_matrix` when it is available.
+        For MCMC estimations it is the posterior standard deviation of the
+        sampled ``segment_slip_rate`` variable.
+        """
         if self.state_covariance_matrix is not None:
             return np.sqrt(
                 np.diag(
@@ -329,6 +384,19 @@ class Estimation:
                     @ self.operators.rotation_to_slip_rate.T
                 )
             )
+        if self.mcmc_trace is not None:
+            posterior = self.mcmc_trace.posterior
+            if "segment_slip_rate" in posterior:
+                rates = posterior["segment_slip_rate"]
+                sample_dims = [dim for dim in ("chain", "draw") if dim in rates.dims]
+                if sample_dims:
+                    sigma = rates.std(sample_dims).values
+                else:
+                    # A single draw: no spread to report
+                    sigma = np.zeros(rates.shape)
+                # (n_segments, 3) with components (strike, dip, tensile)
+                # -> interleaved like `slip_rates`
+                return np.asarray(sigma, dtype=float).ravel()
         return None
 
     @property
@@ -641,14 +709,14 @@ class Estimation:
             return None
         return vel[2::3]
 
-    @property
+    @cached_property
     def tde_kinematic_smooth(self) -> dict[int, np.ndarray]:
         """Dictionary mapping mesh indices to smoothed kinematic slip rate arrays."""
         return self.operators.kinematic_slip_rate(
             self.state_vector, mesh_idx=None, smooth=True
         )
 
-    @property
+    @cached_property
     def tde_kinematic(self) -> dict[int, np.ndarray]:
         """Dictionary mapping mesh indices to kinematic slip rate arrays."""
         return self.operators.kinematic_slip_rate(

--- a/celeri/solve_mcmc.py
+++ b/celeri/solve_mcmc.py
@@ -1819,10 +1819,14 @@ def _state_vector_from_draw(
     The state vector uses eigen coefficients (not TDE values) so that
     Estimation.predictions uses eigen_to_velocities for forward predictions.
 
-    For elastic mode, we use the elastic_eigen_* coefficients directly.
-    For coupling mode, we project the elastic TDE values onto eigenvectors
-    to get equivalent elastic eigen coefficients, since coupling coefficients
-    parameterize the coupling field rather than elastic slip directly.
+    The eigen coefficients are the projection of the sampled elastic TDE
+    field (``elastic_*``) onto the eigenvectors, for both the coupling and
+    the elastic parameterization. This is what the sampler's forward model
+    sees (with ``project_to_eigen`` the velocities are ``T @ V.T @ elastic``),
+    and for the elastic parameterization it includes the prior mean offset
+    and any bound transform, which the raw ``elastic_eigen_*`` coefficients
+    do not. Those coefficients are only used as a fallback when the elastic
+    field is not in the trace.
     """
     assert operators.eigen is not None
     assert operators.index.eigen is not None
@@ -1858,14 +1862,14 @@ def _state_vector_from_draw(
             elastic_eigen_var = f"elastic_eigen_{mesh_idx}_{kind_short}"
             elastic_tde_var = f"elastic_{mesh_idx}_{kind_short}"
 
-            if elastic_eigen_var in posterior_point:
-                coefs[coef_start : coef_start + n_modes] = posterior_point[
-                    elastic_eigen_var
-                ].values
-            elif elastic_tde_var in posterior_point:
+            if elastic_tde_var in posterior_point:
                 elastic_tde = posterior_point[elastic_tde_var].values
                 eigenvectors = _get_eigenmodes(model, mesh_idx, kind)
                 coefs[coef_start : coef_start + n_modes] = eigenvectors.T @ elastic_tde
+            elif elastic_eigen_var in posterior_point:
+                coefs[coef_start : coef_start + n_modes] = posterior_point[
+                    elastic_eigen_var
+                ].values
 
         state_vector[start:end] = coefs
 

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -1,14 +1,102 @@
 from pathlib import Path
 
 import h5py
+import numpy as np
+import pandas as pd
 import pytest
 from loguru import logger
+from numpy.testing import assert_allclose
 
 import celeri
 from celeri.celeri_util import get_newest_run_folder
 from celeri.mesh import ScalarBound
 
 test_logger = logger.bind(name="test_output_files")
+
+
+def _assert_mcmc_outputs_consistent(estimation, run_dir):
+    """model_meshes.csv, the HDF5 file and model_segment.csv of an MCMC run all
+    report the posterior mean (and std) of the sampled fields, and agree with
+    each other.
+    """
+    posterior = estimation.mcmc_trace.posterior
+    posterior_mean = posterior.mean(["chain", "draw"])
+    meshes = pd.read_csv(run_dir / "model_meshes.csv")
+    segment = pd.read_csv(run_dir / "model_segment.csv")
+
+    with h5py.File(run_dir / f"model_{run_dir.name}.hdf5", "r") as hdf:
+        for i in range(len(estimation.model.meshes)):
+            rows = meshes[meshes["mesh_idx"] == i]
+            grp = hdf[f"meshes/mesh_{i:05}"]
+            # What the sampler used: unsmoothed, linear in the rotation, so
+            # the rate at the posterior mean rotation is the posterior mean.
+            kinematic = estimation.operators.kinematic_slip_rate(
+                estimation.state_vector, i, smooth=False
+            )
+            for kind, key, component in (
+                ("ss", "strike_slip", 0),
+                ("ds", "dip_slip", 1),
+            ):
+                rate = rows[f"{key}_rate"].to_numpy()
+                assert_allclose(
+                    rate, posterior_mean[f"elastic_{i}_{kind}"].values, rtol=1e-6
+                )
+                kinematic_rate = rows[f"{key}_rate_kinematic"].to_numpy()
+                assert_allclose(kinematic_rate, kinematic[component::2], rtol=1e-6)
+                kinematic_var = f"kinematic_{i}_{kind}"
+                if kinematic_var in posterior_mean:
+                    # The sampler evaluates its operators in float32
+                    assert_allclose(
+                        kinematic_rate,
+                        posterior_mean[kinematic_var].values,
+                        rtol=1e-4,
+                        atol=1e-4,
+                    )
+                coupling_var = f"coupling_{i}_{kind}"
+                if coupling_var in posterior_mean:
+                    expected_coupling = posterior_mean[coupling_var].values
+                else:
+                    with np.errstate(divide="ignore", invalid="ignore"):
+                        expected_coupling = rate / kinematic[component::2]
+                assert_allclose(
+                    rows[f"{key}_coupling"],
+                    expected_coupling,
+                    rtol=1e-6,
+                    equal_nan=True,
+                )
+                # The HDF5 file carries the same arrays as the CSV
+                for suffix, column in (
+                    ("", f"{key}_rate"),
+                    ("_kinematic", f"{key}_rate_kinematic"),
+                    ("_coupling", f"{key}_coupling"),
+                ):
+                    assert_allclose(
+                        grp[f"{key}{suffix}/{0:012}"][...],
+                        rows[column],
+                        rtol=1e-12,
+                        equal_nan=True,
+                    )
+
+    # Segment rates are the posterior mean and their uncertainties the
+    # posterior std (the CSV is written with 4 decimals)
+    segment_mean = posterior_mean["segment_slip_rate"].values
+    segment_std = posterior["segment_slip_rate"].std(["chain", "draw"]).values
+    for component, name in enumerate(("strike", "dip", "tensile")):
+        assert_allclose(
+            segment[f"model_{name}_slip_rate"], segment_mean[:, component], atol=5e-4
+        )
+        uncertainty = segment[f"model_{name}_slip_rate_uncertainty"]
+        assert np.isfinite(uncertainty).all()
+        assert_allclose(uncertainty, segment_std[:, component], atol=1e-4)
+
+    # Station predictions from the state vector match the sampler's forward model
+    mu = posterior_mean["mu"].values
+    assert_allclose(
+        estimation.station["model_east_vel"], mu[:, 0], rtol=1e-4, atol=1e-3
+    )
+    assert_allclose(
+        estimation.station["model_north_vel"], mu[:, 1], rtol=1e-4, atol=1e-3
+    )
 
 
 @pytest.mark.parametrize(
@@ -89,3 +177,35 @@ def test_celeri_solve_mcmc_creates_output_files(config_file):
     groups = trace.children if hasattr(trace, "children") else trace.groups()
     assert "posterior" in groups
     assert "log_likelihood" in groups
+
+    # Coupling mode: the coupling field itself is sampled
+    assert "coupling_0_ds" in estimation.mcmc_trace.posterior
+    _assert_mcmc_outputs_consistent(estimation, run_dir)
+
+
+@pytest.mark.parametrize(
+    "config_file",
+    [
+        "data/config/wna_config.json",
+    ],
+)
+def test_celeri_solve_mcmc_elastic_mode_output_files(config_file):
+    """Elastic mode with bounded rates: the bound transform makes the sampled
+    elastic field nonlinear in the eigen coefficients, and the outputs must
+    still report its posterior mean and match the sampler's predictions.
+    """
+    config = celeri.get_config(config_file)
+    config.solve_type = "mcmc"
+    model = celeri.build_model(config)
+    for mesh in model.meshes:
+        mesh.config.coupling_constraints_ss = ScalarBound(lower=None, upper=None)
+        mesh.config.coupling_constraints_ds = ScalarBound(lower=None, upper=None)
+        assert mesh.config.elastic_constraints_ds.upper is not None
+    estimation = celeri.solve_mcmc(model, sample_kwargs={"tune": 2, "draws": 2})
+    celeri.write_output(estimation)
+    run_dir = get_newest_run_folder(base=Path(__file__).parent.parent / "runs")
+
+    posterior = estimation.mcmc_trace.posterior
+    assert "coupling_0_ds" not in posterior
+    assert "elastic_eigen_0_ds" in posterior
+    _assert_mcmc_outputs_consistent(estimation, run_dir)


### PR DESCRIPTION
Fixes #506.

## Problem

For MCMC runs the three output files disagreed about the same mesh:

| | `model_meshes.csv` (before) | HDF5 (before) |
|---|---|---|
| `strike_slip_rate` / `dip_slip_rate` | posterior-mean elastic field **projected onto the truncated eigenmode basis** (`V Vᵀ mean(elastic)`), not `mean(elastic)` | same projection |
| `*_kinematic` | Gaussian-smoothed kinematic rate (0.25° default), which the sampler never used | unsmoothed |
| `*_coupling` | posterior mean of `coupling_*` | ratio `projected elastic / unsmoothed kinematic` (blows up where kinematic ≈ 0) |

`model_segment.csv` uncertainty columns were NaN for MCMC runs even though the posterior std of `segment_slip_rate` is in the trace.

## Changes

- **`Estimation.mesh_slip_fields(mesh_idx)`** is the single source for the per-mesh rate / kinematic / coupling arrays. For MCMC: posterior means of `elastic_*` and `coupling_*`, and the unsmoothed kinematic rate the sampler used (equal to its posterior mean, since it is linear in the rotation). Non-MCMC solvers keep their previous semantics. `model_meshes.csv` and the HDF5 mesh datasets are both built from it, so they now agree. (Side effect: for non-MCMC eigen runs the HDF5 kinematic/coupling are now the smoothed versions the CSV already had.)
- **Segment uncertainties** for MCMC come from the posterior std of `segment_slip_rate`.
- **`_state_vector_from_draw`** projects the sampled `elastic_*` field for both parameterizations. Previously elastic mode used the raw `elastic_eigen_*` coefficients, which drop the prior-mean offset and bound transform; a no-op for coupling mode and unbounded elastic mode with zero mean.
- Posterior mean is computed once per estimation and tolerates single-draw subsets from `mcmc_draw()`.

## Verification

- Against an existing Cascadia coupling-mode run: CSV rate/coupling == posterior mean (1e-16), kinematic == posterior mean (1.5e-6, float32 sampler), all six HDF5 datasets == CSV, segment uncertainties == posterior std (CSV rounding), station predictions == posterior `mu`.
- New shared assertion helper in `tests/test_output_files.py` checks CSV == HDF5 == posterior (means, stds, `mu`) in the existing coupling-mode MCMC test and a new bounded-elastic-mode test. `tests/test_output_files.py`, `tests/test_solve_mcmc.py`, `tests/test_serialize.py` pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
