### PR TITLE
Fixing some issues in celeri_forward

### DIFF
--- a/celeri/scripts/celeri_forward.py
+++ b/celeri/scripts/celeri_forward.py
@@ -271,7 +271,9 @@ def compute_forward_velocities_batch(estimation, batch_operators):
         vel_tde = np.zeros(2 * n_stations_batch)
 
     # Compute total velocities
-    vel_total = vel_rotation + vel_elastic_segment
+    vel_total = (
+        vel_rotation - vel_elastic_segment + vel_tde + vel_block_strain_rate + vel_mogi
+    )
 
     # Compute residuals (forward model - observed, but observed is zero for forward stations)
     vel_residual = vel_total

--- a/celeri/scripts/celeri_forward.py
+++ b/celeri/scripts/celeri_forward.py
@@ -217,8 +217,9 @@ def compute_forward_velocities_batch(estimation, batch_operators):
                 # TDE slip is stored as [strike_slip, dip_slip] pairs, so we need the 2-component index
                 tde_keep_col_index = get_keep_index_12(tde_op.shape[1])
 
+                # Negation of this operator is for consistency with the eigen case
                 tde_contribution = (
-                    tde_op[tde_keep_row_index, :][:, tde_keep_col_index]
+                    -tde_op[tde_keep_row_index, :][:, tde_keep_col_index]
                     @ state_vector[
                         index.tde.start_tde_col[mesh_idx] : index.tde.end_tde_col[
                             mesh_idx


### PR DESCRIPTION
These small changes address the points raised in issue #508 

The combined velocity contributions are adjusted [here](https://github.com/brendanjmeade/celeri/blob/1af9de350ec9e0341ef16202698c0d0f4160e09c/celeri/scripts/celeri_forward.py#L274). 

The non-eigen case's TDE velocities are negated [here](https://github.com/brendanjmeade/celeri/blob/1af9de350ec9e0341ef16202698c0d0f4160e09c/celeri/scripts/celeri_forward.py#L222-L223), for consistency with the eigen case.